### PR TITLE
Don't return value from void function

### DIFF
--- a/answer.d
+++ b/answer.d
@@ -159,7 +159,7 @@ class Answer // most members should be a const
     package size_t currRow;
     
     @property Row front(){ return this[currRow]; }
-    @property void popFront(){ return ++currRow; }
+    @property void popFront(){ ++currRow; }
     @property bool empty(){ return currRow >= rowCount; }
 }
 


### PR DESCRIPTION
popFront() shouldn't return a value, and the library didn't compile on dmd 2.062
