### PR TITLE
Fix warnings for DMD 2.063

### DIFF
--- a/src/dpq2/dpq2/answer.d
+++ b/src/dpq2/dpq2/answer.d
@@ -370,7 +370,7 @@ immutable struct Array
         for(uint i = 0; i < n_elems; ++i )
         {
             ubyte[int.sizeof] size_net;
-            size_net = cell.value[ curr_offset .. curr_offset + size_net.sizeof ];
+            size_net[] = cell.value[ curr_offset .. curr_offset + size_net.sizeof ];
             uint size = bigEndianToNative!uint( size_net );
             if( size == size.max ) // NULL magic number
             {

--- a/src/dpq2/dpq2/query.d
+++ b/src/dpq2/dpq2/query.d
@@ -208,7 +208,7 @@ void _unittest( string connParam )
     
     queryParams p;
     p.sqlCommand = sql_query2;
-    p.args = args;
+    p.args = args[];
 
     auto r2 = conn.exec( p );
 


### PR DESCRIPTION
Исправляет предупреждения для компилятора DMD 2.063:

```
./src/dpq2/dpq2/query.d(211): Warning: explicit slice assignment p.args = (args)[] is better than p.args = args
./src/dpq2/dpq2/answer.d(373): Warning: explicit element-wise assignment (size_net)[] = (*this.cell).value[curr_offset..curr_offset + 4LU] is better than size_net = (*this.cell).value[curr_offset..curr_offset + 4LU]
```

Что бы увидеть ошибки, скомпилируйте с прараметром компилятора "-w" для вывода предупреждений. Подробнее об ошибке можно посмотреть тут:
http://dlang.org/changelog.html#slicecopy
