### PR TITLE
fix compilation on dmd 2.074

### DIFF
--- a/src/dpq2/args.d
+++ b/src/dpq2/args.d
@@ -44,7 +44,7 @@ package struct InternalQueryParams
 
     ValueFormat resultFormat;
 
-    this(in ref QueryParams qp) pure
+    this(in QueryParams* qp) pure
     {
         sqlCommand = &qp.sqlCommand;
         resultFormat = qp.resultFormat;

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -28,8 +28,7 @@ if(is(T == ubyte[]))
     return Value(v, detectOidTypeFromNative!T, false, ValueFormat.BINARY);
 }
 
-@property Value toValue(T)(T v) @trusted
-if(is(T == bool))
+@property Value toValue(T : bool)(T v) @trusted
 {
     ubyte[] buf;
     buf.length = 1;

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -136,8 +136,7 @@ if( is( T == UUID ) )
 }
 
 /// Returns boolean as native bool value
-@property bool binaryValueAs(T)(in Value v)
-if( is( T == bool ) )
+@property bool binaryValueAs(T : bool)(in Value v)
 {
     if(!(v.oidType == OidType.Bool))
         throwTypeComplaint(v.oidType, "bool", __FILE__, __LINE__);

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -18,11 +18,11 @@ mixin template Queries()
 
         return new immutable Answer(container);
     }
-    
+
     /// Perform SQL query to DB
     immutable (Answer) execParams(in ref QueryParams qp)
     {
-        auto p = InternalQueryParams(qp);
+        auto p = InternalQueryParams(&qp);
         auto pgResult = PQexecParams (
                 conn,
                 p.command,
@@ -50,7 +50,7 @@ mixin template Queries()
     /// Submits a command and separate parameters to the server without waiting for the result(s)
     void sendQueryParams(in ref QueryParams qp)
     {
-        auto p = InternalQueryParams(qp);
+        auto p = InternalQueryParams(&qp);
         size_t r = PQsendQueryParams (
                 conn,
                 p.command,
@@ -68,7 +68,7 @@ mixin template Queries()
     /// Sends a request to execute a prepared statement with given parameters, without waiting for the result(s)
     void sendQueryPrepared(in ref QueryParams qp)
     {
-        auto p = InternalQueryParams(qp);
+        auto p = InternalQueryParams(&qp);
         size_t r = PQsendQueryPrepared(
                 conn,
                 p.stmtName,


### PR DESCRIPTION
Two lil issues are fixed here:
- dmd 2.074.0 does not like ref parameters escaping. 
  - Pointers do not have that limitation, so they are used instead.
  - This is likely to need further fixes for use with DIP1000.
- isNumeric!bool and is(T == bool) are both true, so toValue!bool and binaryValueAs!bool are both ambiguous.
  - Use specialization to remove ambiguity.