### PR TITLE
Multiple changes to support some not fully supported types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 .dub
+dub.selections.json

--- a/src/dpq2/connection.d
+++ b/src/dpq2/connection.d
@@ -404,10 +404,16 @@ void _integration_test( string connParam )
         debug import std.experimental.logger;
 
         auto c = new Connection(connParam);
+        auto dbname = c.dbName();
+        auto pver = c.protocolVersion();
+        auto sver = c.serverVersion();
 
-        trace("DB name: ", c.dbName());
-        trace("Protocol version: ", c.protocolVersion());
-        trace("Server version: ", c.serverVersion());
+        debug
+        {
+            trace("DB name: ", dbname);
+            trace("Protocol version: ", pver);
+            trace("Server version: ", sver);
+        }
 
         destroy(c);
     }

--- a/src/dpq2/connection.d
+++ b/src/dpq2/connection.d
@@ -401,7 +401,13 @@ void _integration_test( string connParam )
     assert( PQlibVersion() >= 9_0100 );
 
     {
+        debug import std.experimental.logger;
+
         auto c = new Connection(connParam);
+
+        trace("DB name: ", c.dbName());
+        trace("Protocol version: ", c.protocolVersion());
+        trace("Server version: ", c.serverVersion());
 
         destroy(c);
     }

--- a/src/dpq2/connection.d
+++ b/src/dpq2/connection.d
@@ -254,11 +254,32 @@ class Connection
         return res;
     }
 
+    string dbName() const nothrow
+    {
+        assert(conn);
+
+        return PQdb(conn).fromStringz.to!string;
+    }
+
     string host() const nothrow
     {
         assert(conn);
 
         return PQhost(conn).fromStringz.to!string;
+    }
+
+    int protocolVersion() const nothrow
+    {
+        assert(conn);
+
+        return PQprotocolVersion(conn);
+    }
+
+    int serverVersion() const nothrow
+    {
+        assert(conn);
+
+        return PQserverVersion(conn);
     }
 
     void trace(ref File stream)

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -138,47 +138,47 @@ unittest
     }
 
     {
-        // Date: '2018-1-15' -> [0, 0, 25, 189]
+        // Date: '2018-1-15'
         auto d = Date(2018, 1, 15);
         auto v = toValue(d);
 
-        assert(v.data == [0, 0, 25, 189]);
+        assert(v.oidType == OidType.Date);
         assert(v.as!Date == d);
     }
 
     {
-        // Date: '2000-1-1' -> [0, 0, 0, 0]
+        // Date: '2000-1-1'
         auto d = Date(2000, 1, 1);
         auto v = toValue(d);
 
-        assert(v.data == [0, 0, 0, 0]);
+        assert(v.oidType == OidType.Date);
         assert(v.as!Date == d);
     }
 
     {
-        // Date: '0010-2-20' -> [255, 244, 233, 2]
+        // Date: '0010-2-20'
         auto d = Date(10, 2, 20);
         auto v = toValue(d);
 
-        assert(v.data == [255, 244, 233, 2]);
+        assert(v.oidType == OidType.Date);
         assert(v.as!Date == d);
     }
 
     {
-        // TimeOfDay: '14:29:17' -> [0, 0, 0, 12, 36, 204, 169, 64]
+        // TimeOfDay: '14:29:17'
         auto tod = TimeOfDay(14, 29, 17);
         auto v = toValue(tod);
 
-        assert(v.data == [0, 0, 0, 12, 36, 204, 169, 64]);
+        assert(v.oidType == OidType.Time);
         assert(v.as!TimeOfDay == tod);
     }
 
     {
-        // SysTime: '2017-11-13T14:29:17.075678Z' -> [0, 2, 0, 220, 221, 47, 16, 222]
+        // SysTime: '2017-11-13T14:29:17.075678Z'
         auto t = SysTime.fromISOExtString("2017-11-13T14:29:17.075678Z");
         auto v = toValue(t);
 
-        assert(v.data == [0, 2, 0, 220, 221, 47, 16, 222]);
+        assert(v.oidType == OidType.TimeStampWithZone);
         assert(v.as!SysTime == t);
     }
 
@@ -186,11 +186,11 @@ unittest
         import core.time : usecs;
         import std.datetime.date : DateTime;
 
-        // TimeStampWithoutTZ: '2017-11-13 14:29:17.075678' -> [0, 2, 0, 220, 221, 47, 16, 222]
+        // TimeStampWithoutTZ: '2017-11-13 14:29:17.075678'
         auto t = TimeStampWithoutTZ(DateTime(2017, 11, 13, 14, 29, 17), 75_678.usecs);
         auto v = toValue(t);
 
-        assert(v.data == [0, 2, 0, 220, 221, 47, 16, 222]);
+        assert(v.oidType == OidType.TimeStamp);
         assert(v.as!TimeStampWithoutTZ == t);
     }
 }

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -71,7 +71,9 @@ if (is(Unqual!T == TimeOfDay))
 Value toValue(T)(T v)
 if (is(Unqual!T == TimeStampWithoutTZ))
 {
-    return toValue(cast(SysTime)v); // works similarly to SysTime, but TZ is not used for conversion
+    auto val = toValue(cast(SysTime)v); // works similarly to SysTime, but TZ is not used for conversion
+    val.oidType = OidType.TimeStamp;
+    return val;
 }
 
 /// Constructs Value from SysTime
@@ -178,5 +180,17 @@ unittest
 
         assert(v.data == [0, 2, 0, 220, 221, 47, 16, 222]);
         assert(v.as!SysTime == t);
+    }
+
+    {
+        import core.time : usecs;
+        import std.datetime.date : DateTime;
+
+        // TimeStampWithoutTZ: '2017-11-13 14:29:17.075678' -> [0, 2, 0, 220, 221, 47, 16, 222]
+        auto t = TimeStampWithoutTZ(DateTime(2017, 11, 13, 14, 29, 17), 75_678.usecs);
+        auto v = toValue(t);
+
+        assert(v.data == [0, 2, 0, 220, 221, 47, 16, 222]);
+        assert(v.as!TimeStampWithoutTZ == t);
     }
 }

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -67,11 +67,11 @@ if (is(Unqual!T == TimeOfDay))
     return Value(nativeToBigEndian(ms).dup, OidType.Time, false);
 }
 
-/// Constructs Value from TimeStampWithoutTZ with possibility to set timezone it's
-Value toValue(T)(T v, immutable TimeZone tz = LocalTime())
+/// Constructs Value from TimeStampWithoutTZ
+Value toValue(T)(T v)
 if (is(Unqual!T == TimeStampWithoutTZ))
 {
-    auto us = (v.toSysTime(tz) - SysTime(POSTGRES_EPOCH_DATE, tz)).total!"usecs";
+    auto us = (v.toSysTime(UTC()) - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
     return Value(nativeToBigEndian(us).dup, OidType.TimeStamp, false);
 }
 

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -2,9 +2,22 @@ module dpq2.conv.from_d_types;
 
 @safe:
 
-import dpq2;
+import dpq2.conv.time : POSTGRES_EPOCH_DATE, TimeStampWithoutTZ;
+import dpq2.oids : detectOidTypeFromNative, OidType;
+import dpq2.value : Value, ValueFormat;
 import std.bitmanip: nativeToBigEndian;
-import std.traits: isNumeric;
+import std.datetime.date : Date, TimeOfDay;
+import std.datetime.systime : SysTime, UTC;
+import std.traits: isNumeric, TemplateArgsOf, Unqual;
+import std.typecons : Nullable;
+
+/// Converts Nullable!T to Value
+Value toValue(T)(T v)
+    if (is(T == Nullable!R, R))
+{
+    if (v.isNull) return Value(null, detectOidTypeFromNative!(TemplateArgsOf!T[0]), true);
+    return toValue(v.get);
+}
 
 Value toValue(T)(T v)
 if(isNumeric!(T))
@@ -29,6 +42,7 @@ if(is(T == ubyte[]))
 }
 
 Value toValue(T : bool)(T v) @trusted
+if (!is(T == Nullable!R, R))
 {
     ubyte[] buf;
     buf.length = 1;
@@ -37,8 +51,41 @@ Value toValue(T : bool)(T v) @trusted
     return Value(buf, detectOidTypeFromNative!T, false, ValueFormat.BINARY);
 }
 
+/// Constructs Value from Date
+Value toValue(T)(T v)
+if (is(Unqual!T == Date))
+{
+    auto days = cast(int)(v - POSTGRES_EPOCH_DATE).total!"days";
+    return Value(nativeToBigEndian(days).dup, OidType.Date, false);
+}
+
+/// Constructs Value from TimeOfDay
+Value toValue(T)(T v)
+if (is(Unqual!T == TimeOfDay))
+{
+    long ms = (v.second + v.minute*60L + v.hour*3_600L)*1_000_000;
+    return Value(nativeToBigEndian(ms).dup, OidType.Time, false);
+}
+
+/// Constructs Value from TimeStampWithoutTZ
+Value toValue(T)(T v)
+if (is(Unqual!T == TimeStampWithoutTZ))
+{
+    return toValue(cast(SysTime)v); // works similarly to SysTime, but TZ is not used for conversion
+}
+
+/// Constructs Value from SysTime
+Value toValue(T)(T v)
+if (is(Unqual!T == SysTime))
+{
+    auto us = (v - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
+    return Value(nativeToBigEndian(us).dup, OidType.TimeStampWithZone, false);
+}
+
 unittest
 {
+    import dpq2.conv.to_d_types : as;
+
     {
         Value v = toValue(cast(short) 123);
 
@@ -74,5 +121,62 @@ unittest
 
         assert(t.as!bool == true);
         assert(f.as!bool == false);
+    }
+
+    {
+        Value v = toValue(Nullable!long(1));
+        Value nv = toValue(Nullable!bool.init);
+
+        assert(!v.isNull);
+        assert(v.oidType == OidType.Int8);
+        assert(v.as!long == 1);
+
+        assert(nv.isNull);
+        assert(nv.oidType == OidType.Bool);
+    }
+
+    {
+        // Date: '2018-1-15' -> [0, 0, 25, 189]
+        auto d = Date(2018, 1, 15);
+        auto v = toValue(d);
+
+        assert(v.data == [0, 0, 25, 189]);
+        assert(v.as!Date == d);
+    }
+
+    {
+        // Date: '2000-1-1' -> [0, 0, 0, 0]
+        auto d = Date(2000, 1, 1);
+        auto v = toValue(d);
+
+        assert(v.data == [0, 0, 0, 0]);
+        assert(v.as!Date == d);
+    }
+
+    {
+        // Date: '0010-2-20' -> [255, 244, 233, 2]
+        auto d = Date(10, 2, 20);
+        auto v = toValue(d);
+
+        assert(v.data == [255, 244, 233, 2]);
+        assert(v.as!Date == d);
+    }
+
+    {
+        // TimeOfDay: '14:29:17' -> [0, 0, 0, 12, 36, 204, 169, 64]
+        auto tod = TimeOfDay(14, 29, 17);
+        auto v = toValue(tod);
+
+        assert(v.data == [0, 0, 0, 12, 36, 204, 169, 64]);
+        assert(v.as!TimeOfDay == tod);
+    }
+
+    {
+        // SysTime: '2017-11-13T14:29:17.075678Z' -> [0, 2, 0, 220, 221, 47, 16, 222]
+        auto t = SysTime.fromISOExtString("2017-11-13T14:29:17.075678Z");
+        auto v = toValue(t);
+
+        assert(v.data == [0, 2, 0, 220, 221, 47, 16, 222]);
+        assert(v.as!SysTime == t);
     }
 }

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -71,7 +71,7 @@ if (is(Unqual!T == TimeOfDay))
 Value toValue(T)(T v)
 if (is(Unqual!T == TimeStampWithoutTZ))
 {
-    auto us = (v.toSysTime(UTC()) - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
+    auto us = (SysTime(v.dateTime, v.fracSec, UTC()) - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
     return Value(nativeToBigEndian(us).dup, OidType.TimeStamp, false);
 }
 

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -201,8 +201,8 @@ if (is(T == TimeStampWithoutTZ) || (is(T == SysTime)))
 
 void j2date(int jd, out int year, out int month, out int day)
 {
-    enum POSTGRES_EPOCH_JDATE = 2451545;
     enum MONTHS_PER_YEAR = 12;
+    enum POSTGRES_EPOCH_JDATE = 2_451_545;
 
     jd += POSTGRES_EPOCH_JDATE;
 
@@ -315,17 +315,10 @@ struct pg_tm
 
 alias pg_time_t = long;
 
-immutable ulong SECS_PER_DAY = 86400;
-immutable ulong POSTGRES_EPOCH_JDATE = 2451545;
-immutable ulong UNIX_EPOCH_JDATE     = 2440588;
-
-immutable ulong USECS_PER_DAY    = 86_400_000_000;
-immutable ulong USECS_PER_HOUR   = 3_600_000_000;
-immutable ulong USECS_PER_MINUTE = 60_000_000;
-immutable ulong USECS_PER_SEC    = 1_000_000;
-
-immutable ulong SECS_PER_HOUR   = 3600;
-immutable ulong SECS_PER_MINUTE = 60;
+enum USECS_PER_DAY       = 86_400_000_000UL;
+enum USECS_PER_HOUR      = 3_600_000_000UL;
+enum USECS_PER_MINUTE    = 60_000_000UL;
+enum USECS_PER_SEC       = 1_000_000UL;
 
 /**
 * timestamp2tm() - Convert timestamp data type to POSIX time structure.

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -115,7 +115,7 @@ struct TimeStampWithoutTZ
     }
 
     /// Converts the value to SysTime with possibility to set the time zone it's in
-    SysTime toSysTime(immutable TimeZone tz = LocalTime()) const
+    SysTime toSysTime(immutable TimeZone tz) const
     {
         return SysTime(dateTime, fracSec, tz);
     }

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -95,8 +95,9 @@ struct TimeStampWithoutTZ
 
     invariant()
     {
-        assert(fracSec >= Duration.zero);
-        assert(fracSec < 1.seconds);
+        import std.conv : to;
+        assert(fracSec >= Duration.zero, fracSec.to!string);
+        assert(fracSec < 1.seconds, fracSec.to!string);
     }
 
     /// Returns the TimeStampWithoutTZ farthest in the future which is representable by TimeStampWithoutTZ.

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -95,6 +95,8 @@ struct TimeStampWithoutTZ
     DateTime dateTime; /// date and time of TimeStamp
     Duration fracSec; /// fractional seconds
 
+    alias dateTime this;
+
     invariant()
     {
         import std.conv : to;
@@ -132,6 +134,17 @@ struct TimeStampWithoutTZ
         );
     }
 
+    /++
+        Creates timestamp without timezone from DateTime.
+    +/
+    static TimeStampWithoutTZ fromDateTime(in DateTime time)
+    {
+        return TimeStampWithoutTZ(
+            DateTime(time.year, time.month, time.day, time.hour, time.minute, time.second),
+            Duration.zero
+        );
+    }
+
     unittest
     {
         {
@@ -139,7 +152,7 @@ struct TimeStampWithoutTZ
 
             auto t = Clock.currTime; // TZ = local time
             auto ts = TimeStampWithoutTZ.fromSysTime(t);
-            auto uts = ts.toSysTime; // TZ = local time
+            auto uts = ts.toSysTime(LocalTime()); // TZ = local time
 
             assert(t.timezone.name == LocalTime().name);
             assert(uts.timezone.name == LocalTime().name);
@@ -149,7 +162,7 @@ struct TimeStampWithoutTZ
 
             t = Clock.currTime(UTC()); // TZ = UTC
             ts = TimeStampWithoutTZ.fromSysTime(t);
-            uts = ts.toSysTime; // TZ = local time
+            uts = ts.toSysTime(LocalTime()); // TZ = local time
 
             assert(t.hour == ts.dateTime.hour);
             assert(ts.dateTime.hour == uts.hour);
@@ -163,6 +176,12 @@ struct TimeStampWithoutTZ
             // check timezone is dropped
             auto t = TimeStampWithoutTZ.fromSysTime(SysTime.fromISOExtString("2017-11-13T14:29:17.075678+02"));
             assert(t.dateTime.hour == 14);
+        }
+        {
+            auto dt = DateTime(2017, 11, 13, 14, 29, 17);
+            auto t = TimeStampWithoutTZ(dt, 75_678.usecs);
+
+            assert(t == dt); // test the implicit conversion to DateTime
         }
     }
 }

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -31,6 +31,7 @@ alias PGuuid =          UUID; /// UUID
 alias PGdate =          Date; /// Date (no time of day)
 alias PGtime_without_time_zone = TimeOfDay; /// Time of day (no date)
 alias PGtimestamp_without_time_zone = TimeStampWithoutTZ; /// Both date and time (no time zone)
+alias PGtimestamp_with_time_zone = SysTime; /// Both date and time with time zone
 alias PGjson =          Json; /// json or jsonb
 
 package void throwTypeComplaint(OidType receivedType, string expectedType, string file, size_t line) pure
@@ -178,6 +179,7 @@ if( is( T == Json ) )
 public void _integration_test( string connParam ) @system
 {
     auto conn = new Connection(connParam);
+    conn.exec("set timezone to 0"); // to return times in UTC and so make the test reproducible in databases with other TZ
 
     QueryParams params;
     params.resultFormat = ValueFormat.BINARY;
@@ -185,13 +187,38 @@ public void _integration_test( string connParam ) @system
     {
         void testIt(T)(T nativeValue, string pgType, string pgValue)
         {
-            params.sqlCommand = "SELECT "~pgValue~"::"~pgType~" as d_type_test_value";
+            import std.algorithm : strip;
+            import std.format : format;
+            import std.string : representation;
+
+            // test string to native conversion
+            params.sqlCommand = format("SELECT %s::%s as d_type_test_value", pgValue, pgType);
+            params.args = null;
             auto answer = conn.execParams(params);
             immutable Value v = answer[0][0];
             auto result = v.as!T;
 
-            assert(result == nativeValue, "Received unexpected value\nreceived pgType="~to!string(v.oidType)~"\nexpected nativeType="~to!string(typeid(T))~
-                "\nsent pgValue="~pgValue~"\nexpected nativeValue="~to!string(nativeValue)~"\nresult="~to!string(result));
+            assert(result == nativeValue,
+                format("Received unexpected value\nreceived pgType=%s\nexpected nativeType=%s\nsent pgValue=%s\nexpected nativeValue=%s\nresult=%s",
+                v.oidType, typeid(T), pgValue, nativeValue, result)
+            );
+
+            //TODO: Implement toValue for all tested types and remove the condition
+            static if (!is(T == UUID) && !is(T == const(ubyte[])) && !is(T == Json) && !is(T == TimeStampWithoutTZ))
+            {
+                // test binary to text conversion
+                params.sqlCommand = "SELECT $1::text";
+                params.args = [nativeValue.toValue];
+                auto answer2 = conn.execParams(params);
+                auto v2 = answer2[0][0];
+                auto textResult = v2.as!string;
+
+                assert(textResult == pgValue.strip('\''),
+                    format("Received unexpected value\nreceived pgType=%s\nsent nativeType=%s\nsent nativeValue=%s\nexpected pgValue=%s\nresult=%s\nexpectedRepresentation=%s\nreceivedRepresentation=%s",
+                    v.oidType, typeid(T), nativeValue, pgValue, textResult, pgValue.representation, textResult.representation)
+                );
+            }
+            else pragma(msg, T, " Is not tested in integration tests!");
         }
 
         alias C = testIt; // "C" means "case"
@@ -204,7 +231,7 @@ public void _integration_test( string connParam ) @system
         C!PGreal(-12.3456f, "real", "-12.3456");
         C!PGdouble_precision(-1234.56789012345, "double precision", "-1234.56789012345");
         C!PGtext("first line\nsecond line", "text", "'first line\nsecond line'");
-        C!PGtext("12345 ", "char(6)", "'12345'");
+        C!PGtext("12345 ", "char(6)", "'12345 '");
         C!PGbytea([0x44, 0x20, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x00, 0x21],
             "bytea", r"E'\\x44 20 72 75 6c 65 73 00 21'"); // "D rules\x00!" (ASCII)
         C!PGuuid(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640"), "uuid", "'8b9ab33a-96e9-499b-9c36-aad1fe86d640'");
@@ -243,20 +270,21 @@ public void _integration_test( string connParam ) @system
             C!PGnumeric(s, "numeric", s);
 
         // date and time testing
-        C!PGdate(Date(2016, 01, 8), "date", "'January 8, 2016'");
+        C!PGdate(Date(2016, 01, 8), "date", "'2016-01-08'");
         C!PGtime_without_time_zone(TimeOfDay(12, 34, 56), "time without time zone", "'12:34:56'");
         C!PGtimestamp_without_time_zone(TimeStampWithoutTZ(DateTime(1997, 12, 17, 7, 37, 16), dur!"usecs"(12)), "timestamp without time zone", "'1997-12-17 07:37:16.000012'");
         C!PGtimestamp_without_time_zone(TimeStampWithoutTZ.max, "timestamp without time zone", "'infinity'");
         C!PGtimestamp_without_time_zone(TimeStampWithoutTZ.min, "timestamp without time zone", "'-infinity'");
+        C!PGtimestamp_with_time_zone(SysTime(DateTime(1997, 12, 17, 7, 37, 16), dur!"usecs"(12), new immutable SimpleTimeZone(2.dur!"hours")), "timestamp with time zone", "'1997-12-17 05:37:16.000012+00'");
 
         // json
-        C!PGjson(Json(["float_value": Json(123.456), "text_str": Json("text string")]), "json", "'{\"float_value\": 123.456,\"text_str\": \"text string\"}'");
+        C!PGjson(Json(["float_value": Json(123.456), "text_str": Json("text string")]), "json", `'{"float_value": 123.456,"text_str": "text string"}'`);
 
         // json as string
-        C!string("{\"float_value\": 123.456}", "json", "'{\"float_value\": 123.456}'");
+        C!string(`{"float_value": 123.456}`, "json", `'{"float_value": 123.456}'`);
 
         // jsonb
         C!PGjson(Json(["float_value": Json(123.456), "text_str": Json("text string"), "abc": Json(["key": Json("value")])]), "jsonb",
-            "'{\"float_value\": 123.456, \"text_str\": \"text string\", \"abc\": {\"key\": \"value\"}}'");
+            `'{"float_value": 123.456, "text_str": "text string", "abc": {"key": "value"}}'`);
     }
 }

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -287,7 +287,7 @@ public void _integration_test( string connParam ) @system
 
         // append LocalTime offset (SysTime.toISOExtString in LocalTime doesn't append the TZ offset)
         auto splitRes = LocalTime().utcOffsetAt(sysTime.stdTime).split!("hours", "minutes");
-        sysTimeText ~= splitRes.hours > 0 ? "+" : "-";
+        sysTimeText ~= splitRes.hours >= 0 ? "+" : "-";
         sysTimeText ~= format!"%02d"(abs(splitRes.hours));
         if (splitRes.minutes > 0) sysTimeText ~= format!":%02d"(abs(splitRes.minutes));
 

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -210,9 +210,10 @@ public void _integration_test( string connParam ) @system
                 params.args = [nativeValue.toValue];
                 auto answer2 = conn.execParams(params);
                 auto v2 = answer2[0][0];
-                auto textResult = v2.as!string;
+                auto textResult = v2.as!string.strip(' ');
+                pgValue = pgValue.strip('\'');
 
-                assert(textResult == pgValue.strip('\''),
+                assert(textResult == pgValue,
                     format("Received unexpected value\nreceived pgType=%s\nsent nativeType=%s\nsent nativeValue=%s\nexpected pgValue=%s\nresult=%s\nexpectedRepresentation=%s\nreceivedRepresentation=%s",
                     v.oidType, typeid(T), nativeValue, pgValue, textResult, pgValue.representation, textResult.representation)
                 );
@@ -230,7 +231,7 @@ public void _integration_test( string connParam ) @system
         C!PGreal(-12.3456f, "real", "-12.3456");
         C!PGdouble_precision(-1234.56789012345, "double precision", "-1234.56789012345");
         C!PGtext("first line\nsecond line", "text", "'first line\nsecond line'");
-        C!PGtext("12345 ", "char(6)", "'12345 '");
+        C!PGtext("12345 ", "char(6)", "'12345'");
         C!PGbytea([0x44, 0x20, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x00, 0x21],
             "bytea", r"E'\\x44 20 72 75 6c 65 73 00 21'"); // "D rules\x00!" (ASCII)
         C!PGuuid(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640"), "uuid", "'8b9ab33a-96e9-499b-9c36-aad1fe86d640'");
@@ -274,7 +275,7 @@ public void _integration_test( string connParam ) @system
         C!PGtimestamp_without_time_zone(TimeStampWithoutTZ(DateTime(1997, 12, 17, 7, 37, 16), dur!"usecs"(12)), "timestamp without time zone", "'1997-12-17 07:37:16.000012'");
         C!PGtimestamp_without_time_zone(TimeStampWithoutTZ.max, "timestamp without time zone", "'infinity'");
         C!PGtimestamp_without_time_zone(TimeStampWithoutTZ.min, "timestamp without time zone", "'-infinity'");
-        C!PGtimestamp_with_time_zone(SysTime(DateTime(1997, 12, 17, 7, 37, 16), dur!"usecs"(12), new immutable SimpleTimeZone(2.dur!"hours")), "timestamp with time zone", "'1997-12-17 05:37:16.000012+00'");
+        C!SysTime(SysTime(DateTime(1997, 12, 17, 7, 37, 16), dur!"usecs"(12), new immutable SimpleTimeZone(2.dur!"hours")), "timestamp with time zone", "'1997-12-17 05:37:16.000012+00'");
 
         // json
         C!PGjson(Json(["float_value": Json(123.456), "text_str": Json("text string")]), "json", `'{"float_value": 123.456,"text_str": "text string"}'`);

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -31,7 +31,6 @@ alias PGuuid =          UUID; /// UUID
 alias PGdate =          Date; /// Date (no time of day)
 alias PGtime_without_time_zone = TimeOfDay; /// Time of day (no date)
 alias PGtimestamp_without_time_zone = TimeStampWithoutTZ; /// Both date and time (no time zone)
-alias PGtimestamp_with_time_zone = SysTime; /// Both date and time with time zone
 alias PGjson =          Json; /// json or jsonb
 
 package void throwTypeComplaint(OidType receivedType, string expectedType, string file, size_t line) pure

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -148,20 +148,22 @@ OidType detectOidTypeFromNative(T)()
     import std.datetime.systime : SysTime;
     import std.traits : Unqual;
 
+    alias UT = Unqual!T;
+
     with(OidType)
     {
-        static if(is(Unqual!T == string)){ return Text; } else
-        static if(is(Unqual!T == ubyte[])){ return ByteArray; } else
-        static if(is(Unqual!T == bool)){ return Bool; } else
-        static if(is(Unqual!T == short)){ return Int2; } else
-        static if(is(Unqual!T == int)){ return Int4; } else
-        static if(is(Unqual!T == long)){ return Int8; } else
-        static if(is(Unqual!T == float)){ return Float4; } else
-        static if(is(Unqual!T == double)){ return Float8; } else
-        static if(is(Unqual!T == StdDate)){ return Date; } else
-        static if(is(Unqual!T == TimeOfDay)){ return Time; } else
-        static if(is(Unqual!T == SysTime)){ return TimeStampWithZone; } else
-        static if(is(Unqual!T == TimeStampWithoutTZ)){ return TimeStamp; } else
+        static if(is(UT == string)){ return Text; } else
+        static if(is(UT == ubyte[])){ return ByteArray; } else
+        static if(is(UT == bool)){ return Bool; } else
+        static if(is(UT == short)){ return Int2; } else
+        static if(is(UT == int)){ return Int4; } else
+        static if(is(UT == long)){ return Int8; } else
+        static if(is(UT == float)){ return Float4; } else
+        static if(is(UT == double)){ return Float8; } else
+        static if(is(UT == StdDate)){ return Date; } else
+        static if(is(UT == TimeOfDay)){ return Time; } else
+        static if(is(UT == SysTime)){ return TimeStampWithZone; } else
+        static if(is(UT == TimeStampWithoutTZ)){ return TimeStamp; } else
 
         static assert(false, "Unsupported D type: "~T.stringof);
     }
@@ -192,46 +194,46 @@ enum OidType : Oid
     AttributeCatalog = 75,
     ProcCatalog = 81,
     ClassCatalog = 83,
-    
+
     Json = 114,
     Jsonb = 3802,
     Xml = 142,
     NodeTree = 194,
     StorageManager = 210,
-    
+
     Point = 600,
     LineSegment = 601,
     Path = 602,
     Box = 603,
     Polygon = 604,
     Line = 628,
-    
+
     Float4 = 700,
     Float8 = 701,
     AbsTime = 702,
     RelTime = 703,
     Interval = 704,
     Unknown = 705,
-    
+
     Circle = 718,
     Money = 790,
     MacAddress = 829,
     HostAddress = 869,
     NetworkAddress = 650,
-    
+
     FixedString = 1042,
     VariableString = 1043,
-    
+
     Date = 1082,
     Time = 1083,
     TimeStamp = 1114,
     TimeStampWithZone = 1184,
     TimeInterval = 1186,
     TimeWithZone = 1266,
-    
+
     FixedBitString = 1560,
     VariableBitString = 1562,
-    
+
     Numeric = 1700,
     RefCursor = 1790,
     RegProcWithArgs = 2202,
@@ -239,7 +241,7 @@ enum OidType : Oid
     RegOperatorWithArgs = 2204,
     RegClass = 2205,
     RegType = 2206,
-    
+
     UUID = 2950,
     TSVector = 3614,
     GTSVector = 3642,
@@ -247,14 +249,14 @@ enum OidType : Oid
     RegConfig = 3734,
     RegDictionary = 3769,
     TXidSnapshot = 2970,
-    
+
     Int4Range = 3904,
     NumRange = 3906,
     TimeStampRange = 3908,
     TimeStampWithZoneRange = 3910,
     DateRange = 3912,
     Int8Range = 3926,
-    
+
     // Arrays
     XmlArray = 143,
     JsonArray = 3807,
@@ -319,7 +321,7 @@ enum OidType : Oid
     TimeStampWithZoneRangeArray = 3911,
     DateRangeArray = 3913,
     Int8RangeArray = 3927,
-    
+
     // Pseudo types
     Record = 2249,
     RecordArray = 2287,

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -100,7 +100,11 @@ shared static this()
             A(Int4, Int4Array),
             A(Int8, Int8Array),
             A(Float4, Float4Array),
-            A(Float8, Float8Array)
+            A(Float8, Float8Array),
+            A(Date, DateArray),
+            A(Time, TimeArray),
+            A(TimeStampWithZone, TimeStampWithZoneArray),
+            A(TimeStamp, TimeStampArray)
         ];
 
         appropriateArrOid = a;
@@ -140,16 +144,24 @@ bool isSupportedArray(OidType t) pure
 
 OidType detectOidTypeFromNative(T)()
 {
+    import std.datetime.date : StdDate = Date, TimeOfDay;
+    import std.datetime.systime : SysTime;
+    import std.traits : Unqual;
+
     with(OidType)
     {
-        static if(is(T == string)){ return Text; } else
-        static if(is(T == ubyte[])){ return ByteArray; } else
-        static if(is(T == bool)){ return Bool; } else
-        static if(is(T == short)){ return Int2; } else
-        static if(is(T == int)){ return Int4; } else
-        static if(is(T == long)){ return Int8; } else
-        static if(is(T == float)){ return Float4; } else
-        static if(is(T == double)){ return Float8; } else
+        static if(is(Unqual!T == string)){ return Text; } else
+        static if(is(Unqual!T == ubyte[])){ return ByteArray; } else
+        static if(is(Unqual!T == bool)){ return Bool; } else
+        static if(is(Unqual!T == short)){ return Int2; } else
+        static if(is(Unqual!T == int)){ return Int4; } else
+        static if(is(Unqual!T == long)){ return Int8; } else
+        static if(is(Unqual!T == float)){ return Float4; } else
+        static if(is(Unqual!T == double)){ return Float8; } else
+        static if(is(Unqual!T == StdDate)){ return Date; } else
+        static if(is(Unqual!T == TimeOfDay)){ return Time; } else
+        static if(is(Unqual!T == SysTime)){ return TimeStampWithZone; } else
+        static if(is(Unqual!T == TimeStampWithoutTZ)){ return TimeStamp; } else
 
         static assert(false, "Unsupported D type: "~T.stringof);
     }
@@ -285,7 +297,7 @@ enum OidType : Oid
     TimeStampWithZoneArray = 1185,
     TimeIntervalArray = 1187,
     NumericArray = 1231,
-    TimeWithZoneArray = 1270, 
+    TimeWithZoneArray = 1270,
     FixedBitStringArray = 1561,
     VariableBitStringArray = 1563,
     RefCursorArray = 2201,

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -91,7 +91,7 @@ mixin template Queries()
     }
 
     /// Submits a request to create a prepared statement with the given parameters, and waits for completion.
-    immutable(Result) prepare(string statementName, string sqlStatement, const(Oid)[] oids...)
+    immutable(Result) prepare(string statementName, string sqlStatement, in Oid[] oids = null)
     {
         PGresult* pgResult = PQprepare(
                 conn,
@@ -128,14 +128,14 @@ mixin template Queries()
     }
 
     /// Sends a request to create a prepared statement with the given parameters, without waiting for completion.
-    void sendPrepare(string statementName, string sqlStatement)
+    void sendPrepare(string statementName, string sqlStatement, in Oid[] oids = null)
     {
         size_t r = PQsendPrepare(
                 conn,
                 toStringz(statementName),
                 toStringz(sqlStatement),
-                0,
-                null
+                oids.length.to!int,
+                cast(Oid*)oids.ptr //const should be accepted here, see https://github.com/DerelictOrg/DerelictPQ/issues/21
             );
 
         if(r != 1) throw new ConnectionException(this, __FILE__, __LINE__);

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -101,14 +101,14 @@ mixin template Queries()
     }
 
     /// Submits a request to create a prepared statement with the given parameters, and waits for completion.
-    immutable(Result) prepare(string statementName, string sqlStatement)
+    immutable(Result) prepare(string statementName, string sqlStatement, const(Oid)[] oids...)
     {
         PGresult* pgResult = PQprepare(
                 conn,
                 toStringz(statementName),
                 toStringz(sqlStatement),
-                0,
-                null
+                oids.length.to!int,
+                oids.ptr
             );
 
         // is guaranteed by libpq that the result will not be changed until it will not be destroyed

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -293,6 +293,12 @@ void _integration_test( string connParam ) @trusted
         // uses PQprepare:
         auto s = conn.prepare("prepared statement 1", "SELECT $1::integer");
         assert(s.status == PGRES_COMMAND_OK);
+
+        QueryParams p;
+        p.preparedStatementName = "prepared statement 1";
+        p.args = [42.toValue];
+        auto r = conn.execPrepared(p);
+        assert (r[0][0].as!int == 42);
     }
     {
         // uses PQsendPrepare:

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -9,24 +9,14 @@ import std.exception: enforce;
 mixin template Queries()
 {
     /// Perform SQL query to DB
-    immutable (Answer) exec( string SQLcmd, ValueFormat resultFormat = ValueFormat.TEXT )
+    immutable (Answer) exec( string SQLcmd )
     {
-        if (resultFormat == ValueFormat.TEXT)
-        {
-            auto pgResult = PQexec(conn, toStringz( SQLcmd ));
-            // is guaranteed by libpq that the result will not be changed until it will not be destroyed
-            auto container = createResultContainer(cast(immutable) pgResult);
+        auto pgResult = PQexec(conn, toStringz( SQLcmd ));
 
-            return new immutable Answer(container);
-        }
-        else
-        {
-            QueryParams qp;
-            qp.sqlCommand = SQLcmd;
-            qp.resultFormat = resultFormat;
+        // is guaranteed by libpq that the result will not be changed until it will not be destroyed
+        auto container = createResultContainer(cast(immutable) pgResult);
 
-            return execParams(qp);
-        }
+        return new immutable Answer(container);
     }
 
     /// Perform SQL query to DB

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -117,6 +117,26 @@ mixin template Queries()
         return new immutable Result(container);
     }
 
+    /// Submits a request to execute a prepared statement with given parameters, and waits for completion.
+    immutable(Answer) execPrepared(in ref QueryParams qp)
+    {
+        auto p = InternalQueryParams(&qp);
+        auto pgResult = PQexecPrepared(
+                conn,
+                p.stmtName,
+                p.nParams,
+                cast(const(char*)*)p.paramValues,
+                p.paramLengths,
+                p.paramFormats,
+                p.resultFormat
+            );
+
+        // is guaranteed by libpq that the result will not be changed until it will not be destroyed
+        auto container = createResultContainer(cast(immutable) pgResult);
+
+        return new immutable Answer(container);
+    }
+
     /// Sends a request to create a prepared statement with the given parameters, without waiting for completion.
     void sendPrepare(string statementName, string sqlStatement)
     {


### PR DESCRIPTION
I tried to split it to separate commits so it can be reviewed easier.
About Date/Time type values I've added toValue methods so they can be sent directly to the DB but one thing I'm not sure about is support for `version (Have_Int64_TimeStamp)`. I've not implemented the old `double` behavior (which is a deprecated compile switch in all actually supported PG versions).

Either way I think that the current `dpq2.conv.time` can be further simplified using Phobos library.