### PR TITLE
Move derelict load to static constructor

### DIFF
--- a/src/dpq2/package.d
+++ b/src/dpq2/package.d
@@ -2,25 +2,31 @@
 
 debug import std.experimental.logger;
 
-shared static this()
+static __gshared bool __initialized;
+
+static this()
 {
-    debug
-    {
-        trace("DerelictPQ loading...");
-    }
+    import std.concurrency : initOnce;
+    initOnce!__initialized({
+        debug
+        {
+            trace("DerelictPQ loading...");
+        }
 
-    DerelictPQ.load();
+        DerelictPQ.load();
 
-    debug
-    {
-        trace("...DerelictPQ loading finished");
-    }
+        debug
+        {
+            trace("...DerelictPQ loading finished");
+        }
+        return true;
+    }());
 }
 
 public
 {
     import derelict.pq.pq;
-    
+
     import dpq2.connection;
     import dpq2.query;
     import dpq2.result;


### PR DESCRIPTION
This make possible to setup `DerelictPQ.missingSymbolCallback`. So it is possible to use this library even with previous versions of libpq.so with some missing symbols.