### PR TITLE
support of Have_Int64_TimeStamp is removed

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,6 @@
 	"authors": [
 		"Denis Feklushkin", "Anton Gushcha"
 	],
-	"versions": ["Have_Int64_TimeStamp"],
 	"targetPath": "bin",
 	"dependencies": {
 		"derelict-pq": "~>3.0.0-alpha.2",


### PR DESCRIPTION
Have_Int64_TimeStamp removed due to HAVE_INT64_TIMESTAMP removal from libpq source (Postgres commit on 24 Feb 2017 b9d092c962ea3262930e3c31a8c3d79b66ce9d43)