### PR TITLE
Put integration tests under version switch so it won't compile in

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -29,7 +29,8 @@
 			{
 				"dpq2": "*"
 			},
-			"sourcePath": "integration_tests"
+			"sourcePath": "integration_tests",
+			"versions": ["integration_tests"]
 		},
 		{
 			"name": "example",

--- a/src/dpq2/connection.d
+++ b/src/dpq2/connection.d
@@ -403,6 +403,7 @@ class ConnectionException : Dpq2Exception
     }
 }
 
+version (integration_tests)
 void _integration_test( string connParam )
 {
     assert( PQlibVersion() >= 9_0100 );

--- a/src/dpq2/conv/to_bson.d
+++ b/src/dpq2/conv/to_bson.d
@@ -167,6 +167,7 @@ Bson rawValueToBson(in Value v, immutable TimeZone tz = null)
     return res;
 }
 
+version (integration_tests)
 public void _integration_test( string connParam )
 {
     import dpq2.connection: Connection;
@@ -180,9 +181,9 @@ public void _integration_test( string connParam )
     {
         auto a = conn.exec(
                 "SELECT 123::int8 as int_num_value,"~
-                       "'text string'::text as text_value,"~
-                       "'123.456'::json as json_numeric_value,"~
-                       "'\"json_value_string\"'::json as json_text_value"
+                    "'text string'::text as text_value,"~
+                    "'123.456'::json as json_numeric_value,"~
+                    "'\"json_value_string\"'::json as json_text_value"
             );
 
         auto r = a[0]; // first row

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -189,6 +189,7 @@ if( is( T == Json ) )
     return res;
 }
 
+version (integration_tests)
 public void _integration_test( string connParam ) @system
 {
     import std.algorithm : endsWith;

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -217,6 +217,7 @@ enum WaitType
     READ_WRITE
 }
 
+version (integration_tests)
 void _integration_test( string connParam ) @trusted
 {
     import dpq2.conv.to_d_types;

--- a/src/dpq2/result.d
+++ b/src/dpq2/result.d
@@ -667,6 +667,7 @@ class AnswerException : Dpq2Exception
 
 package immutable msg_NOT_BINARY = "Format of the column is not binary";
 
+version (integration_tests)
 void _integration_test( string connParam )
 {
     import core.exception: AssertError;
@@ -704,13 +705,13 @@ void _integration_test( string connParam )
         "-2147483646::integer as integer_value, "~
         "'first line\nsecond line'::text, "~
         "array[[[1,  2, 3], "~
-               "[4,  5, 6]], "~
+            "[4,  5, 6]], "~
 
-              "[[7,  8, 9], "~
-              "[10, 11,12]], "~
+            "[[7,  8, 9], "~
+            "[10, 11,12]], "~
 
-              "[[13,14,NULL], "~
-               "[16,17,18]]]::integer[] as test_array, "~
+            "[[13,14,NULL], "~
+            "[16,17,18]]]::integer[] as test_array, "~
         "NULL::smallint,"~
         "array[11,22,NULL,44]::integer[] as small_array, "~
         "array['1','23',NULL,'789A']::text[] as text_array, "~


### PR DESCRIPTION
Well I also changed intendation of the inner block which is resulting in an overcomplicated diff here, but it is just added `version (integration_tests)` before each of `_integration_test` method and surrounding `{}`