### PR TITLE
Geometry refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
 
 script:
   - dub run dpq2:integration_tests --build=unittest -- --conninfo="${CONN_STRING}"
+  - dub run dpq2:integration_tests --build=release -- --conninfo="${CONN_STRING}"
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Features
  * Some data and time types
  * JSON type (stored into vibe.data.json.Json)
  * JSONB type (ditto)
+ * Geometric types
 * Conversion of values to BSON (into vibe.data.bson.Bson)
 * Access to PostgreSQL's multidimensional arrays
 * LISTEN/NOTIFY support

--- a/dub.json
+++ b/dub.json
@@ -28,7 +28,8 @@
 			"targetType": "executable",
 			"dependencies":
 			{
-				"dpq2": "*"
+				"dpq2": "*",
+				"gfm:math": "~>7.0.0"
 			},
 			"sourcePath": "integration_tests",
 			"versions": ["integration_tests"]

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -3,7 +3,7 @@ module dpq2.conv.from_d_types;
 
 @safe:
 
-public import dpq2.conv.geometric : toValue;
+import dpq2.conv.geometric : toValue;
 import dpq2.conv.time : POSTGRES_EPOCH_DATE, TimeStamp, TimeStampUTC;
 import dpq2.oids : detectOidTypeFromNative, OidType;
 import dpq2.value : Value, ValueFormat;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -363,7 +363,7 @@ if(isInstanceOf!(Circle, T))
 }
 
 version (integration_tests)
-mixin template GeometricInstancesForIntegrationTest()
+package mixin template GeometricInstancesForIntegrationTest()
 {
     @safe:
 

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -11,17 +11,17 @@ import std.range.primitives: ElementType;
 
 private template GetRvalueOfMember(T, string memberName)
 {
-    mixin("
-    static if(is(T."~memberName~" == function))
-        alias R = ReturnType!(T."~memberName~");
+    mixin("alias MemberType = typeof(T."~memberName~");");
+
+    static if(is(MemberType == function))
+        alias R = ReturnType!(MemberType);
     else
-        alias R = typeof(T."~memberName~");
-    ");
+        alias R = MemberType;
 
     alias GetRvalueOfMember = R;
 }
 
-///
+/// Checks that type have "x" and "y" members of returning type "double"
 bool isValidPointType(T)()
 {
     static if(__traits(compiles, typeof(T.x)) && __traits(compiles, typeof(T.y)))
@@ -34,7 +34,7 @@ bool isValidPointType(T)()
         return false;
 }
 
-///
+/// Checks that type have "min" and "max" members of suitable returning type of point
 bool isValidBoxType(T)()
 {
     static if(__traits(compiles, typeof(T.min)) && __traits(compiles, typeof(T.max)))

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -16,8 +16,6 @@ private bool isValidPointType(T)()
 
 private bool isValidBoxType(T)()
 {
-    import gfm.math;
-
     // TODO: reduce code duplication, use hasMember
     static if(__traits(compiles, isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max))))
         return isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max));
@@ -27,8 +25,6 @@ private bool isValidBoxType(T)()
 
 private bool isValidLineSegmentType(T)()
 {
-    import gfm.math;
-
     static if(__traits(compiles, isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b))))
         return isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b));
     else

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -45,11 +45,6 @@ private bool isValidPolygon(T)()
     return isArray!T && isValidPointType!(ElementType!T);
 }
 
-private bool isValidCircle(T)()
-{
-    return isInstanceOf!(Circle, T);
-}
-
 private auto serializePoint(Vec2Ddouble, T)(Vec2Ddouble point, T target)
 if(isValidPointType!Vec2Ddouble)
 {
@@ -97,6 +92,7 @@ struct Line
 
 ///
 struct Path(Point)
+if(isValidPointType!Point)
 {
     bool isClosed;
     Point[] points;
@@ -170,8 +166,8 @@ if(isValidPolygon!Polygon)
     return Value(data, OidType.Polygon, false);
 }
 
-Value toValue(Circle)(Circle c)
-if(isValidCircle!Circle)
+Value toValue(T)(T c)
+if(isInstanceOf!(Circle, T))
 {
     import std.algorithm : copy;
 
@@ -316,8 +312,8 @@ if(isValidPolygon!Polygon)
     return res;
 }
 
-Circle binaryValueAs(Circle)(in Value v)
-if(isValidCircle!Circle)
+T binaryValueAs(T)(in Value v)
+if(isInstanceOf!(Circle, T))
 {
     if(!(v.oidType == OidType.Circle))
         throwTypeComplaint(v.oidType, "Circle", __FILE__, __LINE__);
@@ -326,9 +322,9 @@ if(isValidCircle!Circle)
         throw new AE(ET.SIZE_MISMATCH,
             "Value length isn't equal to Postgres Circle size", __FILE__, __LINE__);
 
-    alias Point = typeof(Circle.center);
+    alias Point = typeof(T.center);
 
-    return Circle(
+    return T(
         v.data[0..16].pointFromBytes!Point,
         v.data[16..24].bigEndianToNative!double
     );

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -45,7 +45,7 @@ private bool isValidBoxType(T)()
     //~ else
         //~ return false;
 
-    // TODO: swizzle in gfm.math.vector works wrong
+    // TODO: swizzle in gfm.math.vector works wrong: https://github.com/d-gamedev-team/gfm/issues/195
     // TODO: GetRvalueOfMember can be simplified?
     static if(__traits(compiles, isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max))))
         return isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max));

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -177,7 +177,8 @@ if(isInstanceOf!(Circle, T))
 private alias AE = ValueConvException;
 private alias ET = ConvExceptionType;
 
-Vec2Ddouble binaryValueAsPoint(Vec2Ddouble)(in Value v)
+/// Convert to Point
+Vec2Ddouble binaryValueAs(Vec2Ddouble)(in Value v)
 if(isValidPointType!Vec2Ddouble)
 {
     if(!(v.oidType == OidType.Point))
@@ -330,6 +331,7 @@ version (integration_tests)
 mixin template InstancesForIntegrationTest()
 {
     import gfm.math;
+    import dpq2.conv.geometric: Circle, Path;
 
     alias Point = vec2d;
     alias Box = box2d;
@@ -360,7 +362,7 @@ unittest
     // binary write/read
     {
         auto pt = Point(1,2);
-        assert(pt.toValue.binaryValueAsPoint!Point == pt);
+        assert(pt.toValue.binaryValueAs!Point == pt);
 
         auto ln = Line(1,2,3);
         assert(ln.toValue.binaryValueAs!Line == ln);
@@ -390,7 +392,7 @@ unittest
 
         auto v = Point(1,1).toValue;
         v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAsPoint!Point);
+        assertThrown!ValueConvException(v.binaryValueAs!Point);
 
         v = Line(1,2,3).toValue;
         v.oidType = OidType.Text;
@@ -423,7 +425,7 @@ unittest
 
         auto v = Point(1,1).toValue;
         v._data = new ubyte[1];
-        assertThrown!ValueConvException(v.binaryValueAsPoint!Point);
+        assertThrown!ValueConvException(v.binaryValueAs!Point);
 
         v = Line(1,2,3).toValue;
         v._data.length = 1;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -53,9 +53,12 @@ bool isValidBoxType(T)()
 ///
 bool isValidLineSegmentType(T)()
 {
-    // TODO: reduce duplication
-    static if(__traits(compiles, isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b))))
-        return isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b));
+    static if(__traits(compiles, typeof(T.start)) && __traits(compiles, typeof(T.end)))
+    {
+        return
+            isValidPointType!(GetRvalueOfMember!(T, "start")) &&
+            isValidPointType!(GetRvalueOfMember!(T, "end"));
+    }
     else
         return false;
 }

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -35,10 +35,10 @@ private bool isValidLineSegmentType(T)()
         return false;
 }
 
-private bool isValidPathType(T)()
-{
-    return isInstanceOf!(Path, T) /*&& isValidPointType!(typeof(T.points))*/; //FIXME
-}
+//~ private bool isValidPathType(T)()
+//~ {
+    //~ return isInstanceOf!(Path, T) /*&& isValidPointType!(typeof(T.points))*/; //FIXME
+//~ }
 
 private bool isValidPolygon(T)()
 {
@@ -130,8 +130,8 @@ if(isValidLineSegmentType!LineSegment)
     return Value(data, OidType.LineSegment, false);
 }
 
-Value toValue(Path)(Path path)
-if(isValidPathType!Path)
+Value toValue(T)(T path)
+if(isInstanceOf!(Path, T))
 {
     import std.algorithm : copy;
 
@@ -251,8 +251,8 @@ if(isValidBoxType!Box)
     return Box(min, max);
 }
 
-Path binaryValueAs(Path)(in Value v)
-if(isValidPathType!Path)
+T binaryValueAs(T)(in Value v)
+if(isInstanceOf!(Path, T))
 {
     import std.array : uninitializedArray;
 
@@ -263,14 +263,14 @@ if(isValidPathType!Path)
         throw new AE(ET.SIZE_MISMATCH,
             "Value length isn't equal to Postgres Path size", __FILE__, __LINE__);
 
-    Path res;
+    T res;
     res.isClosed = v.data[0..1].bigEndianToNative!byte == 1;
     int len = v.data[1..5].bigEndianToNative!int;
 
     if (len != (v.data.length - 5)/16)
         throw new AE(ET.SIZE_MISMATCH, "Path points number mismatch", __FILE__, __LINE__);
 
-    alias Point = typeof(Path.points[0]);
+    alias Point = typeof(T.points[0]);
 
     res.points = uninitializedArray!(Point[])(len);
     for (int i=0; i<len; i++)

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -212,7 +212,7 @@ if (is(T == Line))
     return Line((v.data[0..8].bigEndianToNative!double), v.data[8..16].bigEndianToNative!double, v.data[16..24].bigEndianToNative!double);
 }
 
-LineSegment binaryValueAsLineSegment(LineSegment)(in Value v)
+LineSegment binaryValueAs(LineSegment)(in Value v)
 if(isValidLineSegmentType!LineSegment)
 {
     if(!(v.oidType == OidType.LineSegment))
@@ -330,6 +330,8 @@ if(isInstanceOf!(Circle, T))
 version (integration_tests)
 mixin template InstancesForIntegrationTest()
 {
+    @safe:
+
     import gfm.math;
     import dpq2.conv.geometric: Circle, Path;
 
@@ -368,7 +370,7 @@ unittest
         assert(ln.toValue.binaryValueAs!Line == ln);
 
         auto lseg = LineSegment(Point(1,2),Point(3,4));
-        assert(lseg.toValue.binaryValueAsLineSegment!LineSegment == lseg);
+        assert(lseg.toValue.binaryValueAs!LineSegment == lseg);
 
         auto b = Box(Point(2,2), Point(1,1));
         assert(b.toValue.binaryValueAsBox!Box == b);
@@ -400,7 +402,7 @@ unittest
 
         v = LineSegment(Point(1,1), Point(2,2)).toValue;
         v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAsLineSegment!LineSegment);
+        assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
 
         v = Box(Point(1,1), Point(2,2)).toValue;
         v.oidType = OidType.Text;
@@ -433,7 +435,7 @@ unittest
 
         v = LineSegment(Point(1,1), Point(2,2)).toValue;
         v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAsLineSegment!LineSegment);
+        assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
 
         v = Box(Point(1,1), Point(2,2)).toValue;
         v._data.length = 1;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -279,7 +279,7 @@ if(isInstanceOf!(Path, T))
     return res;
 }
 
-Polygon binaryValueAsPolygon(Polygon)(in Value v)
+Polygon binaryValueAs(Polygon)(in Value v)
 if(isValidPolygon!Polygon)
 {
     import std.array : uninitializedArray;
@@ -382,7 +382,7 @@ unittest
         assert(p.toValue.binaryValueAs!TestPath == p);
 
         Polygon poly = [Point(1,1), Point(2,2), Point(3,3)];
-        assert(poly.toValue.binaryValueAsPolygon!Polygon == poly);
+        assert(poly.toValue.binaryValueAs!Polygon == poly);
 
         auto c = TestCircle(Point(1,2), 3);
         assert(c.toValue.binaryValueAs!TestCircle == c);
@@ -414,7 +414,7 @@ unittest
 
         v = [Point(1,1), Point(2,2)].toValue;
         v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAsPolygon!Polygon);
+        assertThrown!ValueConvException(v.binaryValueAs!Polygon);
 
         v = TestCircle(Point(1,1), 3).toValue;
         v.oidType = OidType.Text;
@@ -449,9 +449,9 @@ unittest
 
         v = [Point(1,1), Point(2,2)].toValue;
         v._data.length -= 16;
-        assertThrown!ValueConvException(v.binaryValueAsPolygon!Polygon);
+        assertThrown!ValueConvException(v.binaryValueAs!Polygon);
         v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAsPolygon!Polygon);
+        assertThrown!ValueConvException(v.binaryValueAs!Polygon);
 
         v = TestCircle(Point(1,1), 3).toValue;
         v._data.length = 1;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -21,7 +21,8 @@ private template GetRvalueOfMember(T, string memberName)
     alias GetRvalueOfMember = R;
 }
 
-private bool isValidPointType(T)()
+///
+bool isValidPointType(T)()
 {
     static if(hasMember!(T, "x") && hasMember!(T, "y"))
     {
@@ -33,7 +34,8 @@ private bool isValidPointType(T)()
         return false;
 }
 
-private bool isValidBoxType(T)()
+///
+bool isValidBoxType(T)()
 {
     //~ static if(hasMember!(T, "m2245s2") && hasMember!(T, "ma333"))
     //~ {
@@ -53,7 +55,8 @@ private bool isValidBoxType(T)()
         return false;
 }
 
-private bool isValidLineSegmentType(T)()
+///
+bool isValidLineSegmentType(T)()
 {
     // TODO: reduce duplication
     static if(__traits(compiles, isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b))))
@@ -62,7 +65,8 @@ private bool isValidLineSegmentType(T)()
         return false;
 }
 
-private bool isValidPolygon(T)()
+///
+bool isValidPolygon(T)()
 {
     return isArray!T && isValidPointType!(ElementType!T);
 }

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -3,7 +3,6 @@ module dpq2.conv.geometric;
 import dpq2.oids: OidType;
 import dpq2.value: ConvExceptionType, throwTypeComplaint, Value, ValueConvException, ValueFormat;
 import std.bitmanip: bigEndianToNative, nativeToBigEndian;
-import std.exception: enforce;
 import std.traits: ReturnType, isInstanceOf, isArray;
 import std.range.primitives: ElementType;
 
@@ -127,7 +126,9 @@ if(isInstanceOf!(Path, T))
 {
     import std.algorithm : copy;
 
-    enforce(path.points.length >= 1, "At least one point is needed for Path");
+    if(path.points.length < 1)
+        throw new ValueConvException(ConvExceptionType.SIZE_MISMATCH,
+            "At least one point is needed for Path", __FILE__, __LINE__);
 
     ubyte[] data = new ubyte[path.points.length * 16 + 5];
 
@@ -147,7 +148,9 @@ if(isValidPolygon!Polygon)
 {
     import std.algorithm : copy;
 
-    enforce(poly.length >= 1, "At least one point is needed for Polygon"); //FIXME: Value conv exception
+    if(poly.length < 1)
+        throw new ValueConvException(ConvExceptionType.SIZE_MISMATCH,
+            "At least one point is needed for Polygon", __FILE__, __LINE__);
 
     ubyte[] data = new ubyte[poly.length * 16 + 4];
     auto rem = (cast(int)poly.length).nativeToBigEndian.copy(data);

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -8,9 +8,8 @@ import std.exception : enforce;
 @safe:
 
 private auto serializePoint(Vec2Ddouble, T)(Vec2Ddouble point, T target)
+if(is(typeof(Vec2Ddouble.x) == double) && is(typeof(Vec2Ddouble.y) == double))
 {
-    //TODO: type of x and y check
-
     import std.algorithm : copy;
 
     auto rem = point.x.nativeToBigEndian.copy(target);

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -101,7 +101,8 @@ if(isValidPointType!Point)
     double radius; ///
 }
 
-Value toValue(Line line)
+Value toValue(T)(T line)
+if(is(T == Line))
 {
     import std.algorithm : copy;
 
@@ -325,9 +326,9 @@ if(isInstanceOf!(Circle, T))
     );
 }
 
-unittest
+version (integration_tests)
+mixin template InstancesForIntegrationTest()
 {
-
     import gfm.math;
 
     alias Point = vec2d;
@@ -349,6 +350,12 @@ unittest
     alias TestPath = Path!Point;
     alias Polygon = Point[];
     alias TestCircle = Circle!Point;
+}
+
+version (integration_tests)
+unittest
+{
+    mixin InstancesForIntegrationTest;
 
     // binary write/read
     {

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -7,8 +7,13 @@ import std.exception : enforce;
 
 @safe:
 
+bool isValidPointType(T)()
+{
+    return is(typeof(T.x) == double) && is(typeof(T.y) == double);
+}
+
 private auto serializePoint(Vec2Ddouble, T)(Vec2Ddouble point, T target)
-if(is(typeof(Vec2Ddouble.x) == double) && is(typeof(Vec2Ddouble.y) == double))
+if(isValidPointType!Vec2Ddouble)
 {
     import std.algorithm : copy;
 
@@ -19,7 +24,7 @@ if(is(typeof(Vec2Ddouble.x) == double) && is(typeof(Vec2Ddouble.y) == double))
 }
 
 Value toValue(Vec2Ddouble)(Vec2Ddouble pt)
-if(is(typeof(Vec2Ddouble.x) == double) && is(typeof(Vec2Ddouble.y) == double))
+if(isValidPointType!Vec2Ddouble)
 {
     ubyte[] data = new ubyte[16];
     pt.serializePoint(data);
@@ -155,6 +160,7 @@ private alias AE = ValueConvException;
 private alias ET = ConvExceptionType;
 
 Vec2Ddouble binaryValueAsPoint(Vec2Ddouble)(in Value v)
+if(isValidPointType!Vec2Ddouble)
 {
     // TODO: Vec2Ddouble x and y types check
 

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -376,9 +376,9 @@ unittest
         v.oidType = OidType.Text;
         assertThrown!ValueConvException(v.binaryValueAs!Line);
 
-        //~ v = LineSegment(Point(1,1), Point(2,2)).toValue;
-        //~ v.oidType = OidType.Text;
-        //~ assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
+        v = LineSegment(Point(1,1), Point(2,2)).toValue;
+        v.oidType = OidType.Text;
+        assertThrown!ValueConvException(v.binaryValueAsLineSegment!LineSegment);
 
         v = Box(Point(1,1), Point(2,2)).toValue;
         v.oidType = OidType.Text;
@@ -409,9 +409,9 @@ unittest
         v._data.length = 1;
         assertThrown!ValueConvException(v.binaryValueAs!Line);
 
-        //~ v = LineSegment(Point(1,1), Point(2,2)).toValue;
-        //~ v._data.length = 1;
-        //~ assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
+        v = LineSegment(Point(1,1), Point(2,2)).toValue;
+        v._data.length = 1;
+        assertThrown!ValueConvException(v.binaryValueAsLineSegment!LineSegment);
 
         v = Box(Point(1,1), Point(2,2)).toValue;
         v._data.length = 1;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -55,6 +55,7 @@ private bool isValidBoxType(T)()
 
 private bool isValidLineSegmentType(T)()
 {
+    // TODO: reduce duplication
     static if(__traits(compiles, isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b))))
         return isValidPointType!(typeof(T.a)) && isValidPointType!(typeof(T.b));
     else

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -60,12 +60,12 @@ if(isValidBoxType!Box)
 }
 
 /// Infinite line - {A,B,C} (Ax + By + C = 0)
-//~ struct Line
-//~ {
-    //~ double a;
-    //~ double b;
-    //~ double c;
-//~ }
+struct Line
+{
+    double a;
+    double b;
+    double c;
+}
 
 /// Finite line segment - ((x1,y1),(x2,y2))
 //~ struct LineSegment
@@ -94,18 +94,18 @@ if(isValidBoxType!Box)
     //~ double radius;
 //~ }
 
-//~ Value toValue(Line line)
-//~ {
-    //~ import std.algorithm : copy;
+Value toValue(Line line)
+{
+    import std.algorithm : copy;
 
-    //~ ubyte[] data = new ubyte[24];
+    ubyte[] data = new ubyte[24];
 
-    //~ auto rem = line.a.nativeToBigEndian.copy(data);
-    //~ rem = line.b.nativeToBigEndian.copy(rem);
-    //~ rem = line.c.nativeToBigEndian.copy(rem);
+    auto rem = line.a.nativeToBigEndian.copy(data);
+    rem = line.b.nativeToBigEndian.copy(rem);
+    rem = line.c.nativeToBigEndian.copy(rem);
 
-    //~ return Value(data, OidType.Line, false);
-//~ }
+    return Value(data, OidType.Line, false);
+}
 
 //~ Value toValue(LineSegment lseg)
 //~ {
@@ -188,19 +188,18 @@ if(isValidPointType!Vec2Ddouble)
     return Vec2Ddouble(data[0..8].bigEndianToNative!double, data[8..16].bigEndianToNative!double);
 }
 
-//~ T binaryValueAs(T)(in Value v)
-//~ if (is(T == Line))
-//~ {
-    //~ if(!(v.oidType == OidType.Line))
-        //~ throwTypeComplaint(v.oidType, "Line", __FILE__, __LINE__);
+T binaryValueAs(T)(in Value v)
+if (is(T == Line))
+{
+    if(!(v.oidType == OidType.Line))
+        throwTypeComplaint(v.oidType, "Line", __FILE__, __LINE__);
 
-    //~ if(!(v.data.length == 24))
-        //~ throw new AE(ET.SIZE_MISMATCH,
-            //~ "Value length isn't equal to Postgres Line size", __FILE__, __LINE__);
+    if(!(v.data.length == 24))
+        throw new AE(ET.SIZE_MISMATCH,
+            "Value length isn't equal to Postgres Line size", __FILE__, __LINE__);
 
-    //~ return Line((v.data[0..8].bigEndianToNative!double), v.data[8..16].bigEndianToNative!double, v.data[16..24].bigEndianToNative!double);
-//~ }
-
+    return Line((v.data[0..8].bigEndianToNative!double), v.data[8..16].bigEndianToNative!double, v.data[16..24].bigEndianToNative!double);
+}
 
 //~ T binaryValueAs(T)(in Value v)
 //~ if (is(T == LineSegment))
@@ -317,8 +316,8 @@ unittest
         auto pt = Point(1,2);
         assert(pt.toValue.binaryValueAsPoint!Point == pt);
 
-        //~ auto ln = Line(1,2,3);
-        //~ assert(ln.toValue.binaryValueAs!Line == ln);
+        auto ln = Line(1,2,3);
+        assert(ln.toValue.binaryValueAs!Line == ln);
 
         //~ auto lseg = LineSegment(Point(1,2),Point(3,4));
         //~ assert(lseg.toValue.binaryValueAs!LineSegment == lseg);
@@ -347,9 +346,9 @@ unittest
         v.oidType = OidType.Text;
         assertThrown!ValueConvException(v.binaryValueAsPoint!Point);
 
-        //~ v = Line(1,2,3).toValue;
-        //~ v.oidType = OidType.Text;
-        //~ assertThrown!ValueConvException(v.binaryValueAs!Line);
+        v = Line(1,2,3).toValue;
+        v.oidType = OidType.Text;
+        assertThrown!ValueConvException(v.binaryValueAs!Line);
 
         //~ v = LineSegment(Point(1,1), Point(2,2)).toValue;
         //~ v.oidType = OidType.Text;
@@ -380,9 +379,9 @@ unittest
         v._data = new ubyte[1];
         assertThrown!ValueConvException(v.binaryValueAsPoint!Point);
 
-        //~ v = Line(1,2,3).toValue;
-        //~ v._data.length = 1;
-        //~ assertThrown!ValueConvException(v.binaryValueAs!Line);
+        v = Line(1,2,3).toValue;
+        v._data.length = 1;
+        assertThrown!ValueConvException(v.binaryValueAs!Line);
 
         //~ v = LineSegment(Point(1,1), Point(2,2)).toValue;
         //~ v._data.length = 1;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -1,16 +1,36 @@
+///
 module dpq2.conv.geometric;
 
 import dpq2.oids: OidType;
 import dpq2.value: ConvExceptionType, throwTypeComplaint, Value, ValueConvException, ValueFormat;
 import std.bitmanip: bigEndianToNative, nativeToBigEndian;
-import std.traits: ReturnType, isInstanceOf, isArray;
+import std.traits;
 import std.range.primitives: ElementType;
 
 @safe:
 
+private bool checkRvalueOfMember(RequiredType, string memberName, T)()
+{
+    static if(!hasMember!(T, memberName))
+        return false;
+    else
+    {
+        mixin("alias member = T."~memberName~";");
+
+        pragma(msg, typeof(member));
+
+        static if(isCallable!T)
+            return is(ReturnType!member == RequiredType);
+        else
+            return is(typeof(member) == RequiredType);
+    }
+}
+
 private bool isValidPointType(T)()
 {
-    return is(typeof(T.x) == double) && is(typeof(T.y) == double);
+    return
+        checkRvalueOfMember!(double, "x", T) &&
+        checkRvalueOfMember!(double, "y", T);
 }
 
 private bool isValidBoxType(T)()

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -11,17 +11,14 @@ import std.range.primitives: ElementType;
 
 private template GetRvalueOfMember(T, string memberName)
 {
-    //~ pragma(msg, "member name: "~memberName);
-
-    mixin("alias Member = T."~memberName~";");
-
-    //~ pragma(msg, "Member.typeof:");
-    //~ pragma(msg, typeof(Member));
-
-    static if(isCallable!T)
-        alias GetRvalueOfMember = ReturnType!Member;
+    mixin("
+    static if(is(T."~memberName~" == function))
+        alias R = ReturnType!(T."~memberName~");
     else
-        alias GetRvalueOfMember = typeof(Member);
+        alias R = typeof(T."~memberName~");
+    ");
+
+    alias GetRvalueOfMember = R;
 }
 
 private bool isValidPointType(T)()
@@ -38,10 +35,18 @@ private bool isValidPointType(T)()
 
 private bool isValidBoxType(T)()
 {
-    //~ return
-        //~ checkRvalueOfMember!(double, "min", T) &&
+    //~ static if(hasMember!(T, "m2245s2") && hasMember!(T, "ma333"))
+    //~ {
+        //~ pragma(msg, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        //~ pragma(msg, T);
 
-    // TODO: reduce code duplication, use hasMember
+        //~ return isValidPointType!(GetRvalueOfMember!(T, "min"));
+    //~ }
+    //~ else
+        //~ return false;
+
+    // TODO: swizzle in gfm.math.vector works wrong
+    // TODO: GetRvalueOfMember can be simplified?
     static if(__traits(compiles, isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max))))
         return isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max));
     else

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -24,7 +24,7 @@ private template GetRvalueOfMember(T, string memberName)
 ///
 bool isValidPointType(T)()
 {
-    static if(hasMember!(T, "x") && hasMember!(T, "y"))
+    static if(__traits(compiles, typeof(T.x)) && __traits(compiles, typeof(T.y)))
     {
         return
             is(GetRvalueOfMember!(T, "x") == double) &&
@@ -37,20 +37,15 @@ bool isValidPointType(T)()
 ///
 bool isValidBoxType(T)()
 {
-    //~ static if(hasMember!(T, "m2245s2") && hasMember!(T, "ma333"))
-    //~ {
-        //~ pragma(msg, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-        //~ pragma(msg, T);
+    static if(__traits(compiles, typeof(T.min)) && __traits(compiles, typeof(T.max)))
+    {
+        pragma(msg, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        pragma(msg, T);
 
-        //~ return isValidPointType!(GetRvalueOfMember!(T, "min"));
-    //~ }
-    //~ else
-        //~ return false;
-
-    // TODO: swizzle in gfm.math.vector works wrong: https://github.com/d-gamedev-team/gfm/issues/195
-    // TODO: GetRvalueOfMember can be simplified?
-    static if(__traits(compiles, isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max))))
-        return isValidPointType!(typeof(T.min)) && isValidPointType!(typeof(T.max));
+        return
+            isValidPointType!(GetRvalueOfMember!(T, "min")) &&
+            isValidPointType!(GetRvalueOfMember!(T, "max"));
+    }
     else
         return false;
 }

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -35,11 +35,6 @@ private bool isValidLineSegmentType(T)()
         return false;
 }
 
-//~ private bool isValidPathType(T)()
-//~ {
-    //~ return isInstanceOf!(Path, T) /*&& isValidPointType!(typeof(T.points))*/; //FIXME
-//~ }
-
 private bool isValidPolygon(T)()
 {
     return isArray!T && isValidPointType!(ElementType!T);

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -230,7 +230,7 @@ if(isValidLineSegmentType!LineSegment)
     return LineSegment(start, end);
 }
 
-Box binaryValueAsBox(Box)(in Value v)
+Box binaryValueAs(Box)(in Value v)
 if(isValidBoxType!Box)
 {
     if(!(v.oidType == OidType.Box))
@@ -373,7 +373,7 @@ unittest
         assert(lseg.toValue.binaryValueAs!LineSegment == lseg);
 
         auto b = Box(Point(2,2), Point(1,1));
-        assert(b.toValue.binaryValueAsBox!Box == b);
+        assert(b.toValue.binaryValueAs!Box == b);
 
         auto p = TestPath(false, [Point(1,1), Point(2,2)]);
         assert(p.toValue.binaryValueAs!TestPath == p);
@@ -406,7 +406,7 @@ unittest
 
         v = Box(Point(1,1), Point(2,2)).toValue;
         v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAsBox!Box);
+        assertThrown!ValueConvException(v.binaryValueAs!Box);
 
         v = TestPath(true, [Point(1,1), Point(2,2)]).toValue;
         v.oidType = OidType.Text;
@@ -439,7 +439,7 @@ unittest
 
         v = Box(Point(1,1), Point(2,2)).toValue;
         v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAsBox!Box);
+        assertThrown!ValueConvException(v.binaryValueAs!Box);
 
         v = TestPath(true, [Point(1,1), Point(2,2)]).toValue;
         v._data.length -= 16;

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -162,8 +162,6 @@ private alias ET = ConvExceptionType;
 Vec2Ddouble binaryValueAsPoint(Vec2Ddouble)(in Value v)
 if(isValidPointType!Vec2Ddouble)
 {
-    // TODO: Vec2Ddouble x and y types check
-
     if(!(v.oidType == OidType.Point))
         throwTypeComplaint(v.oidType, "Point", __FILE__, __LINE__);
 

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -7,12 +7,10 @@ import std.exception : enforce;
 
 @safe:
 
-import gfm.math.vector;
-/// Point on a plane - (x,y)
-alias Point = vec2d;
-
-private auto serialize(T)(Point point, T target)
+private auto serializePoint(Vec2Ddouble, T)(Vec2Ddouble point, T target)
 {
+    //TODO: type of x and y check
+
     import std.algorithm : copy;
 
     auto rem = point.x.nativeToBigEndian.copy(target);
@@ -21,103 +19,86 @@ private auto serialize(T)(Point point, T target)
     return rem;
 }
 
-/// Infinite line - {A,B,C} (Ax + By + C = 0)
-struct Line
+Value toValue(Vec2Ddouble)(Vec2Ddouble pt)
+if(is(typeof(Vec2Ddouble.x) == double) && is(typeof(Vec2Ddouble.y) == double))
 {
-    double a;
-    double b;
-    double c;
+    ubyte[] data = new ubyte[16];
+    pt.serializePoint(data);
+
+    return Value(data, OidType.Point);
 }
 
+import gfm.math.vector;
+alias Point = vec2d;
+
+/// Infinite line - {A,B,C} (Ax + By + C = 0)
+//~ struct Line
+//~ {
+    //~ double a;
+    //~ double b;
+    //~ double c;
+//~ }
+
 /// Finite line segment - ((x1,y1),(x2,y2))
-struct LineSegment
-{
-    Point start;
-    Point end;
-}
+//~ struct LineSegment
+//~ {
+    //~ Point start;
+    //~ Point end;
+//~ }
 
 import gfm.math.box;
 /// Rectangular box - ((x1,y1),(x2,y2))
 alias Box = box2d;
 private auto serialize(T)(Box box, T target)
 {
-    auto rem = box.min.serialize(target);
-    rem = box.max.serialize(rem);
+    auto rem = box.min.serializePoint(target);
+    rem = box.max.serializePoint(rem);
 
     return rem;
 }
 
 /// Closed path (similar to polygon) - ((x1,y1),...)
-struct Path
-{
-    bool closed;
-    Point[] points;
-}
+//~ struct Path
+//~ {
+    //~ bool closed;
+    //~ Point[] points;
+//~ }
 
 /// Polygon (similar to closed path) - ((x1,y1),...)
-struct Polygon
-{
-    Point[] points; /// Polygon's points
-
-    /// Polygon's bounding box
-    //~ @property Box bbox()
-    //~ {
-        //~ import std.algorithm : map, max, min, reduce;
-        //~ enforce(points.length, "No points defined");
-
-        //~ auto lr = points.map!(a=>a.x).reduce!(min, max);
-        //~ auto bt = points.map!(a=>a.y).reduce!(min, max);
-
-        //~ return Box(Point(lr[1], bt[1]), Point(lr[0], bt[0]));
-    //~ }
-
-    //~ unittest
-    //~ {
-        //~ auto poly = Polygon([Point(1,1), Point(2,2), Point(3,3)]);
-        //~ assert(poly.bbox == Box(Point(3,3), Point(1,1)));
-
-        //~ poly = Polygon([Point(0,0), Point(1,1), Point(2,0)]);
-        //~ assert(poly.bbox == Box(Point(2,1), Point(0,0)));
-    //~ }
-}
+//~ struct Polygon
+//~ {
+    //~ Point[] points; /// Polygon's points
+//~ }
 
 /// Circle - <(x,y),r> (center point and radius)
-struct Circle
-{
-    Point center;
-    double radius;
-}
+//~ struct Circle
+//~ {
+    //~ Point center;
+    //~ double radius;
+//~ }
 
-Value toValue(Point pt)
-{
-    ubyte[] data = new ubyte[16];
-    pt.serialize(data);
+//~ Value toValue(Line line)
+//~ {
+    //~ import std.algorithm : copy;
 
-    return Value(data, OidType.Point, false);
-}
+    //~ ubyte[] data = new ubyte[24];
 
-Value toValue(Line line)
-{
-    import std.algorithm : copy;
+    //~ auto rem = line.a.nativeToBigEndian.copy(data);
+    //~ rem = line.b.nativeToBigEndian.copy(rem);
+    //~ rem = line.c.nativeToBigEndian.copy(rem);
 
-    ubyte[] data = new ubyte[24];
+    //~ return Value(data, OidType.Line, false);
+//~ }
 
-    auto rem = line.a.nativeToBigEndian.copy(data);
-    rem = line.b.nativeToBigEndian.copy(rem);
-    rem = line.c.nativeToBigEndian.copy(rem);
+//~ Value toValue(LineSegment lseg)
+//~ {
+    //~ ubyte[] data = new ubyte[32];
 
-    return Value(data, OidType.Line, false);
-}
+    //~ auto rem = lseg.start.serialize(data);
+    //~ rem = lseg.end.serialize(rem);
 
-Value toValue(LineSegment lseg)
-{
-    ubyte[] data = new ubyte[32];
-
-    auto rem = lseg.start.serialize(data);
-    rem = lseg.end.serialize(rem);
-
-    return Value(data, OidType.LineSegment, false);
-}
+    //~ return Value(data, OidType.LineSegment, false);
+//~ }
 
 Value toValue(Box box)
 {
@@ -127,52 +108,52 @@ Value toValue(Box box)
     return Value(data, OidType.Box);
 }
 
-Value toValue(Path path)
-{
-    import std.algorithm : copy;
+//~ Value toValue(Path path)
+//~ {
+    //~ import std.algorithm : copy;
 
-    enforce(path.points.length >= 1, "At least one point is needed for Path");
+    //~ enforce(path.points.length >= 1, "At least one point is needed for Path");
 
-    ubyte[] data = new ubyte[path.points.length * 16 + 5];
+    //~ ubyte[] data = new ubyte[path.points.length * 16 + 5];
 
-    auto rem = (cast(ubyte)(path.closed ? 1 : 0)).nativeToBigEndian.copy(data);
-    rem = (cast(int)path.points.length).nativeToBigEndian.copy(rem);
+    //~ auto rem = (cast(ubyte)(path.closed ? 1 : 0)).nativeToBigEndian.copy(data);
+    //~ rem = (cast(int)path.points.length).nativeToBigEndian.copy(rem);
 
-    foreach (ref p; path.points)
-    {
-        rem = p.serialize(rem);
-    }
+    //~ foreach (ref p; path.points)
+    //~ {
+        //~ rem = p.serialize(rem);
+    //~ }
 
-    return Value(data, OidType.Path, false);
-}
+    //~ return Value(data, OidType.Path, false);
+//~ }
 
-Value toValue(Polygon poly)
-{
-    import std.algorithm : copy;
+//~ Value toValue(Polygon poly)
+//~ {
+    //~ import std.algorithm : copy;
 
-    enforce(poly.points.length >= 1, "At least one point is needed for Polygon");
+    //~ enforce(poly.points.length >= 1, "At least one point is needed for Polygon");
 
-    ubyte[] data = new ubyte[poly.points.length * 16 + 4];
-    auto rem = (cast(int)poly.points.length).nativeToBigEndian.copy(data);
+    //~ ubyte[] data = new ubyte[poly.points.length * 16 + 4];
+    //~ auto rem = (cast(int)poly.points.length).nativeToBigEndian.copy(data);
 
-    foreach (ref p; poly.points)
-    {
-        rem = p.serialize(rem);
-    }
+    //~ foreach (ref p; poly.points)
+    //~ {
+        //~ rem = p.serialize(rem);
+    //~ }
 
-    return Value(data, OidType.Polygon, false);
-}
+    //~ return Value(data, OidType.Polygon, false);
+//~ }
 
-Value toValue(Circle c)
-{
-    import std.algorithm : copy;
+//~ Value toValue(Circle c)
+//~ {
+    //~ import std.algorithm : copy;
 
-    ubyte[] data = new ubyte[24];
-    auto rem = c.center.serialize(data);
-    c.radius.nativeToBigEndian.copy(rem);
+    //~ ubyte[] data = new ubyte[24];
+    //~ auto rem = c.center.serialize(data);
+    //~ c.radius.nativeToBigEndian.copy(rem);
 
-    return Value(data, OidType.Circle, false);
-}
+    //~ return Value(data, OidType.Circle, false);
+//~ }
 
 private alias AE = ValueConvException;
 private alias ET = ConvExceptionType;
@@ -197,147 +178,149 @@ if (is(T == Point) && (is(V == Value) || is(V == const(ubyte)[])))
     return Point(data[0..8].bigEndianToNative!double, data[8..16].bigEndianToNative!double);
 }
 
-T binaryValueAs(T)(in Value v)
-if (is(T == Line))
-{
-    if(!(v.oidType == OidType.Line))
-        throwTypeComplaint(v.oidType, "Line", __FILE__, __LINE__);
+//~ T binaryValueAs(T)(in Value v)
+//~ if (is(T == Line))
+//~ {
+    //~ if(!(v.oidType == OidType.Line))
+        //~ throwTypeComplaint(v.oidType, "Line", __FILE__, __LINE__);
 
-    if(!(v.data.length == 24))
-        throw new AE(ET.SIZE_MISMATCH,
-            "Value length isn't equal to Postgres Line size", __FILE__, __LINE__);
+    //~ if(!(v.data.length == 24))
+        //~ throw new AE(ET.SIZE_MISMATCH,
+            //~ "Value length isn't equal to Postgres Line size", __FILE__, __LINE__);
 
-    return Line((v.data[0..8].bigEndianToNative!double), v.data[8..16].bigEndianToNative!double, v.data[16..24].bigEndianToNative!double);
-}
+    //~ return Line((v.data[0..8].bigEndianToNative!double), v.data[8..16].bigEndianToNative!double, v.data[16..24].bigEndianToNative!double);
+//~ }
 
 
-T binaryValueAs(T)(in Value v)
-if (is(T == LineSegment))
-{
-    if(!(v.oidType == OidType.LineSegment))
-        throwTypeComplaint(v.oidType, "LineSegment", __FILE__, __LINE__);
+//~ T binaryValueAs(T)(in Value v)
+//~ if (is(T == LineSegment))
+//~ {
+    //~ if(!(v.oidType == OidType.LineSegment))
+        //~ throwTypeComplaint(v.oidType, "LineSegment", __FILE__, __LINE__);
 
-    if(!(v.data.length == 32))
-        throw new AE(ET.SIZE_MISMATCH,
-            "Value length isn't equal to Postgres LineSegment size", __FILE__, __LINE__);
+    //~ if(!(v.data.length == 32))
+        //~ throw new AE(ET.SIZE_MISMATCH,
+            //~ "Value length isn't equal to Postgres LineSegment size", __FILE__, __LINE__);
 
-    return LineSegment(v.data[0..16].binaryValueAs!Point, v.data[16..$].binaryValueAs!Point);
-}
+    //~ return LineSegment(v.data[0..16].binaryValueAs!Point, v.data[16..$].binaryValueAs!Point);
+//~ }
 
-T binaryValueAs(T)(in Value v)
-if (is(T == Box))
-{
-    if(!(v.oidType == OidType.Box))
-        throwTypeComplaint(v.oidType, "Box", __FILE__, __LINE__);
+//~ T binaryValueAs(T)(in Value v)
+//~ if (is(T == Box))
+//~ {
+    //~ if(!(v.oidType == OidType.Box))
+        //~ throwTypeComplaint(v.oidType, "Box", __FILE__, __LINE__);
 
-    if(!(v.data.length == 32))
-        throw new AE(ET.SIZE_MISMATCH,
-            "Value length isn't equal to Postgres Box size", __FILE__, __LINE__);
+    //~ if(!(v.data.length == 32))
+        //~ throw new AE(ET.SIZE_MISMATCH,
+            //~ "Value length isn't equal to Postgres Box size", __FILE__, __LINE__);
 
-    return Box(v.data[0..16].binaryValueAs!Point, v.data[16..$].binaryValueAs!Point);
-}
+    //~ return Box(v.data[0..16].binaryValueAs!Point, v.data[16..$].binaryValueAs!Point);
+//~ }
 
-T binaryValueAs(T)(in Value v)
-if (is(T == Path))
-{
-    import std.array : uninitializedArray;
+//~ T binaryValueAs(T)(in Value v)
+//~ if (is(T == Path))
+//~ {
+    //~ import std.array : uninitializedArray;
 
-    if(!(v.oidType == OidType.Path))
-        throwTypeComplaint(v.oidType, "Path", __FILE__, __LINE__);
+    //~ if(!(v.oidType == OidType.Path))
+        //~ throwTypeComplaint(v.oidType, "Path", __FILE__, __LINE__);
 
-    if(!((v.data.length - 5) % 16 == 0))
-        throw new AE(ET.SIZE_MISMATCH,
-            "Value length isn't equal to Postgres Path size", __FILE__, __LINE__);
+    //~ if(!((v.data.length - 5) % 16 == 0))
+        //~ throw new AE(ET.SIZE_MISMATCH,
+            //~ "Value length isn't equal to Postgres Path size", __FILE__, __LINE__);
 
-    T res;
-    res.closed = v.data[0..1].bigEndianToNative!byte == 1;
-    int len = v.data[1..5].bigEndianToNative!int;
+    //~ T res;
+    //~ res.closed = v.data[0..1].bigEndianToNative!byte == 1;
+    //~ int len = v.data[1..5].bigEndianToNative!int;
 
-    if (len != (v.data.length - 5)/16)
-        throw new AE(ET.SIZE_MISMATCH, "Path points number mismatch", __FILE__, __LINE__);
+    //~ if (len != (v.data.length - 5)/16)
+        //~ throw new AE(ET.SIZE_MISMATCH, "Path points number mismatch", __FILE__, __LINE__);
 
-    res.points = uninitializedArray!(Point[])(len);
-    for (int i=0; i<len; i++)
-    {
-        res.points[i] = v.data[(i*16+5)..(i*16+16+5)].binaryValueAs!Point;
-    }
+    //~ res.points = uninitializedArray!(Point[])(len);
+    //~ for (int i=0; i<len; i++)
+    //~ {
+        //~ res.points[i] = v.data[(i*16+5)..(i*16+16+5)].binaryValueAs!Point;
+    //~ }
 
-    return res;
-}
+    //~ return res;
+//~ }
 
-T binaryValueAs(T)(in Value v)
-if (is(T == Polygon))
-{
-    import std.array : uninitializedArray;
+//~ T binaryValueAs(T)(in Value v)
+//~ if (is(T == Polygon))
+//~ {
+    //~ import std.array : uninitializedArray;
 
-    if(!(v.oidType == OidType.Polygon))
-        throwTypeComplaint(v.oidType, "Polygon", __FILE__, __LINE__);
+    //~ if(!(v.oidType == OidType.Polygon))
+        //~ throwTypeComplaint(v.oidType, "Polygon", __FILE__, __LINE__);
 
-    if(!((v.data.length - 4) % 16 == 0))
-        throw new AE(ET.SIZE_MISMATCH,
-            "Value length isn't equal to Postgres Polygon size", __FILE__, __LINE__);
+    //~ if(!((v.data.length - 4) % 16 == 0))
+        //~ throw new AE(ET.SIZE_MISMATCH,
+            //~ "Value length isn't equal to Postgres Polygon size", __FILE__, __LINE__);
 
-    T res;
-    int len = v.data[0..4].bigEndianToNative!int;
+    //~ T res;
+    //~ int len = v.data[0..4].bigEndianToNative!int;
 
-    if (len != (v.data.length - 4)/16)
-        throw new AE(ET.SIZE_MISMATCH, "Path points number mismatch", __FILE__, __LINE__);
+    //~ if (len != (v.data.length - 4)/16)
+        //~ throw new AE(ET.SIZE_MISMATCH, "Path points number mismatch", __FILE__, __LINE__);
 
-    res.points = uninitializedArray!(Point[])(len);
-    for (int i=0; i<len; i++)
-    {
-        res.points[i] = v.data[(i*16+4)..(i*16+16+4)].binaryValueAs!Point;
-    }
+    //~ res.points = uninitializedArray!(Point[])(len);
+    //~ for (int i=0; i<len; i++)
+    //~ {
+        //~ res.points[i] = v.data[(i*16+4)..(i*16+16+4)].binaryValueAs!Point;
+    //~ }
 
-    return res;
-}
+    //~ return res;
+//~ }
 
-T binaryValueAs(T)(in Value v)
-if (is(T == Circle))
-{
-    if(!(v.oidType == OidType.Circle))
-        throwTypeComplaint(v.oidType, "Circle", __FILE__, __LINE__);
+//~ T binaryValueAs(T)(in Value v)
+//~ if (is(T == Circle))
+//~ {
+    //~ if(!(v.oidType == OidType.Circle))
+        //~ throwTypeComplaint(v.oidType, "Circle", __FILE__, __LINE__);
 
-    if(!(v.data.length == 24))
-        throw new AE(ET.SIZE_MISMATCH,
-            "Value length isn't equal to Postgres Circle size", __FILE__, __LINE__);
+    //~ if(!(v.data.length == 24))
+        //~ throw new AE(ET.SIZE_MISMATCH,
+            //~ "Value length isn't equal to Postgres Circle size", __FILE__, __LINE__);
 
-    return Circle(
-        v.data[0..16].binaryValueAs!Point,
-        v.data[16..24].bigEndianToNative!double
-    );
-}
+    //~ return Circle(
+        //~ v.data[0..16].binaryValueAs!Point,
+        //~ v.data[16..24].bigEndianToNative!double
+    //~ );
+//~ }
 
-unittest
-{
+//~ unittest
+//~ {
     // binary write/read
+    unittest
     {
         auto pt = Point(1,2);
         assert(pt.toValue.binaryValueAs!Point == pt);
 
-        auto ln = Line(1,2,3);
-        assert(ln.toValue.binaryValueAs!Line == ln);
+        //~ auto ln = Line(1,2,3);
+        //~ assert(ln.toValue.binaryValueAs!Line == ln);
 
-        auto lseg = LineSegment(Point(1,2),Point(3,4));
-        assert(lseg.toValue.binaryValueAs!LineSegment == lseg);
+        //~ auto lseg = LineSegment(Point(1,2),Point(3,4));
+        //~ assert(lseg.toValue.binaryValueAs!LineSegment == lseg);
 
-        auto b = Box(Point(2,2), Point(1,1));
-        assert(b.toValue.binaryValueAs!Box == b);
+        //~ auto b = Box(Point(2,2), Point(1,1));
+        //~ assert(b.toValue.binaryValueAs!Box == b);
 
-        auto p = Path(false, [Point(1,1), Point(2,2)]);
-        assert(p.toValue.binaryValueAs!Path == p);
+        //~ auto p = Path(false, [Point(1,1), Point(2,2)]);
+        //~ assert(p.toValue.binaryValueAs!Path == p);
 
-        p = Path(true, [Point(1,1), Point(2,2)]);
-        assert(p.toValue.binaryValueAs!Path == p);
+        //~ p = Path(true, [Point(1,1), Point(2,2)]);
+        //~ assert(p.toValue.binaryValueAs!Path == p);
 
-        auto poly = Polygon([Point(1,1), Point(2,2), Point(3,3)]);
-        assert(poly.toValue.binaryValueAs!Polygon == poly);
+        //~ auto poly = Polygon([Point(1,1), Point(2,2), Point(3,3)]);
+        //~ assert(poly.toValue.binaryValueAs!Polygon == poly);
 
-        auto c = Circle(Point(1,2), 3);
-        assert(c.toValue.binaryValueAs!Circle == c);
+        //~ auto c = Circle(Point(1,2), 3);
+        //~ assert(c.toValue.binaryValueAs!Circle == c);
     }
 
     // Invalid OID tests
+    unittest
     {
         import std.exception : assertThrown;
 
@@ -345,32 +328,33 @@ unittest
         v.oidType = OidType.Text;
         assertThrown!ValueConvException(v.binaryValueAs!Point);
 
-        v = Line(1,2,3).toValue;
-        v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAs!Line);
+        //~ v = Line(1,2,3).toValue;
+        //~ v.oidType = OidType.Text;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Line);
 
-        v = LineSegment(Point(1,1), Point(2,2)).toValue;
-        v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
+        //~ v = LineSegment(Point(1,1), Point(2,2)).toValue;
+        //~ v.oidType = OidType.Text;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
 
-        v = Box(Point(1,1), Point(2,2)).toValue;
-        v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAs!Box);
+        //~ v = Box(Point(1,1), Point(2,2)).toValue;
+        //~ v.oidType = OidType.Text;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Box);
 
-        v = Path(true, [Point(1,1), Point(2,2)]).toValue;
-        v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAs!Path);
+        //~ v = Path(true, [Point(1,1), Point(2,2)]).toValue;
+        //~ v.oidType = OidType.Text;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Path);
 
-        v = Polygon([Point(1,1), Point(2,2)]).toValue;
-        v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAs!Polygon);
+        //~ v = Polygon([Point(1,1), Point(2,2)]).toValue;
+        //~ v.oidType = OidType.Text;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Polygon);
 
-        v = Circle(Point(1,1), 3).toValue;
-        v.oidType = OidType.Text;
-        assertThrown!ValueConvException(v.binaryValueAs!Circle);
+        //~ v = Circle(Point(1,1), 3).toValue;
+        //~ v.oidType = OidType.Text;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Circle);
     }
 
     // Invalid data size
+    unittest
     {
         import std.exception : assertThrown;
 
@@ -378,32 +362,32 @@ unittest
         v._data = new ubyte[1];
         assertThrown!ValueConvException(v.binaryValueAs!Point);
 
-        v = Line(1,2,3).toValue;
-        v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAs!Line);
+        //~ v = Line(1,2,3).toValue;
+        //~ v._data.length = 1;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Line);
 
-        v = LineSegment(Point(1,1), Point(2,2)).toValue;
-        v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
+        //~ v = LineSegment(Point(1,1), Point(2,2)).toValue;
+        //~ v._data.length = 1;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!LineSegment);
 
-        v = Box(Point(1,1), Point(2,2)).toValue;
-        v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAs!Box);
+        //~ v = Box(Point(1,1), Point(2,2)).toValue;
+        //~ v._data.length = 1;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Box);
 
-        v = Path(true, [Point(1,1), Point(2,2)]).toValue;
-        v._data.length -= 16;
-        assertThrown!ValueConvException(v.binaryValueAs!Path);
-        v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAs!Path);
+        //~ v = Path(true, [Point(1,1), Point(2,2)]).toValue;
+        //~ v._data.length -= 16;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Path);
+        //~ v._data.length = 1;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Path);
 
-        v = Polygon([Point(1,1), Point(2,2)]).toValue;
-        v._data.length -= 16;
-        assertThrown!ValueConvException(v.binaryValueAs!Polygon);
-        v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAs!Polygon);
+        //~ v = Polygon([Point(1,1), Point(2,2)]).toValue;
+        //~ v._data.length -= 16;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Polygon);
+        //~ v._data.length = 1;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Polygon);
 
-        v = Circle(Point(1,1), 3).toValue;
-        v._data.length = 1;
-        assertThrown!ValueConvException(v.binaryValueAs!Circle);
+        //~ v = Circle(Point(1,1), 3).toValue;
+        //~ v._data.length = 1;
+        //~ assertThrown!ValueConvException(v.binaryValueAs!Circle);
     }
-}
+//~ }

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -39,9 +39,6 @@ bool isValidBoxType(T)()
 {
     static if(__traits(compiles, typeof(T.min)) && __traits(compiles, typeof(T.max)))
     {
-        pragma(msg, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-        pragma(msg, T);
-
         return
             isValidPointType!(GetRvalueOfMember!(T, "min")) &&
             isValidPointType!(GetRvalueOfMember!(T, "max"));

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -328,7 +328,7 @@ if(isInstanceOf!(Circle, T))
 }
 
 version (integration_tests)
-mixin template InstancesForIntegrationTest()
+mixin template GeometricInstancesForIntegrationTest()
 {
     @safe:
 
@@ -359,7 +359,7 @@ mixin template InstancesForIntegrationTest()
 version (integration_tests)
 unittest
 {
-    mixin InstancesForIntegrationTest;
+    mixin GeometricInstancesForIntegrationTest;
 
     // binary write/read
     {

--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -76,17 +76,17 @@ if(isValidBoxType!Box)
 /// Infinite line - {A,B,C} (Ax + By + C = 0)
 struct Line
 {
-    double a;
-    double b;
-    double c;
+    double a; ///
+    double b; ///
+    double c; ///
 }
 
 ///
 struct Path(Point)
 if(isValidPointType!Point)
 {
-    bool isClosed;
-    Point[] points;
+    bool isClosed; ///
+    Point[] points; ///
 }
 
 ///

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -311,10 +311,10 @@ public void _integration_test( string connParam ) @system
             `'{"float_value": 123.456, "text_str": "text string", "abc": {"key": "value"}}'`);
 
         // Geometric
-        import dpq2.conv.geometric: InstancesForIntegrationTest, Circle, Line, Path;
+        import dpq2.conv.geometric: InstancesForIntegrationTest;
         mixin InstancesForIntegrationTest;
 
-        //~ C!Point(Point(1,2), "point", "'(1,2)'");
+        C!Point(Point(1,2), "point", "'(1,2)'");
         C!Line(Line(1,2,3), "line", "'{1,2,3}'");
         //~ C!PGlseg(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
         //~ C!PGbox(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -315,7 +315,7 @@ public void _integration_test( string connParam ) @system
         mixin GeometricInstancesForIntegrationTest;
 
         C!Point(Point(1,2), "point", "'(1,2)'");
-        C!Line(Line(1,2,3), "line", "'{1,2,3}'");
+        C!PGline(Line(1,2,3), "line", "'{1,2,3}'");
         C!LineSegment(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
         C!Box(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
         C!TestPath(TestPath(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -9,9 +9,9 @@ import dpq2.connection: Connection;
 import dpq2.query: QueryParams;
 import dpq2.result: msg_NOT_BINARY;
 import dpq2.conv.from_d_types;
-//~ import dpq2.conv.geometric : binaryValueAs, Box, Circle, Line, LineSegment, Path, Point, Polygon;
 import dpq2.conv.numeric: rawValueToNumeric;
 import dpq2.conv.time: binaryValueAs, TimeStamp, TimeStampUTC;
+import dpq2.conv.geometric: binaryValueAs, Line;
 
 import vibe.data.json: Json, parseJsonString;
 import vibe.data.bson: Bson;
@@ -39,13 +39,7 @@ alias PGtime_without_time_zone = TimeOfDay; /// Time of day (no date)
 alias PGtimestamp = TimeStamp; /// Both date and time without time zone
 alias PGtimestamptz = TimeStampUTC; /// Both date and time stored in UTC time zone
 alias PGjson =          Json; /// json or jsonb
-//~ alias PGpoint =         Point; /// Point
-//~ alias PGline =          Line; /// LineSegment
-//~ alias PGlseg =          LineSegment; /// LineSegment
-//~ alias PGbox =           Box; /// Box
-//~ alias PGpath =          Path; /// Path
-//~ alias PGpolygon =       Polygon; /// Polygon
-//~ alias PGcircle =        Circle; /// Circle
+alias PGline =          Line; /// Line (geometric type)
 
 private alias VF = ValueFormat;
 private alias AE = ValueConvException;
@@ -317,8 +311,11 @@ public void _integration_test( string connParam ) @system
             `'{"float_value": 123.456, "text_str": "text string", "abc": {"key": "value"}}'`);
 
         // Geometric
-        //~ C!PGpoint(Point(1,2), "point", "'(1,2)'");
-        //~ C!PGline(Line(1,2,3), "line", "'{1,2,3}'");
+        import dpq2.conv.geometric: InstancesForIntegrationTest, Circle, Line, Path;
+        mixin InstancesForIntegrationTest;
+
+        //~ C!Point(Point(1,2), "point", "'(1,2)'");
+        C!Line(Line(1,2,3), "line", "'{1,2,3}'");
         //~ C!PGlseg(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
         //~ C!PGbox(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
         //~ C!PGpath(Path(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -311,8 +311,8 @@ public void _integration_test( string connParam ) @system
             `'{"float_value": 123.456, "text_str": "text string", "abc": {"key": "value"}}'`);
 
         // Geometric
-        import dpq2.conv.geometric: InstancesForIntegrationTest;
-        mixin InstancesForIntegrationTest;
+        import dpq2.conv.geometric: GeometricInstancesForIntegrationTest;
+        mixin GeometricInstancesForIntegrationTest;
 
         C!Point(Point(1,2), "point", "'(1,2)'");
         C!Line(Line(1,2,3), "line", "'{1,2,3}'");
@@ -321,6 +321,6 @@ public void _integration_test( string connParam ) @system
         C!TestPath(TestPath(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
         C!TestPath(TestPath(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
         C!Polygon(([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");
-        //~ C!PGcircle(Circle(Point(1,2), 10), "circle", "'<(1,2),10>'");
+        C!TestCircle(TestCircle(Point(1,2), 10), "circle", "'<(1,2),10>'");
     }
 }

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -9,7 +9,7 @@ import dpq2.connection: Connection;
 import dpq2.query: QueryParams;
 import dpq2.result: msg_NOT_BINARY;
 import dpq2.conv.from_d_types;
-import dpq2.conv.geometric : binaryValueAs, Box, Circle, Line, LineSegment, Path, Point, Polygon;
+//~ import dpq2.conv.geometric : binaryValueAs, Box, Circle, Line, LineSegment, Path, Point, Polygon;
 import dpq2.conv.numeric: rawValueToNumeric;
 import dpq2.conv.time: binaryValueAs, TimeStamp, TimeStampUTC;
 
@@ -39,13 +39,13 @@ alias PGtime_without_time_zone = TimeOfDay; /// Time of day (no date)
 alias PGtimestamp = TimeStamp; /// Both date and time without time zone
 alias PGtimestamptz = TimeStampUTC; /// Both date and time stored in UTC time zone
 alias PGjson =          Json; /// json or jsonb
-alias PGpoint =         Point; /// Point
-alias PGline =          Line; /// LineSegment
-alias PGlseg =          LineSegment; /// LineSegment
-alias PGbox =           Box; /// Box
-alias PGpath =          Path; /// Path
-alias PGpolygon =       Polygon; /// Polygon
-alias PGcircle =        Circle; /// Circle
+//~ alias PGpoint =         Point; /// Point
+//~ alias PGline =          Line; /// LineSegment
+//~ alias PGlseg =          LineSegment; /// LineSegment
+//~ alias PGbox =           Box; /// Box
+//~ alias PGpath =          Path; /// Path
+//~ alias PGpolygon =       Polygon; /// Polygon
+//~ alias PGcircle =        Circle; /// Circle
 
 private alias VF = ValueFormat;
 private alias AE = ValueConvException;
@@ -317,13 +317,13 @@ public void _integration_test( string connParam ) @system
             `'{"float_value": 123.456, "text_str": "text string", "abc": {"key": "value"}}'`);
 
         // Geometric
-        C!PGpoint(Point(1,2), "point", "'(1,2)'");
-        C!PGline(Line(1,2,3), "line", "'{1,2,3}'");
-        C!PGlseg(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
-        C!PGbox(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
-        C!PGpath(Path(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
-        C!PGpath(Path(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
-        C!PGpolygon(Polygon([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");
-        C!PGcircle(Circle(Point(1,2), 10), "circle", "'<(1,2),10>'");
+        //~ C!PGpoint(Point(1,2), "point", "'(1,2)'");
+        //~ C!PGline(Line(1,2,3), "line", "'{1,2,3}'");
+        //~ C!PGlseg(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
+        //~ C!PGbox(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
+        //~ C!PGpath(Path(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
+        //~ C!PGpath(Path(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
+        //~ C!PGpolygon(Polygon([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");
+        //~ C!PGcircle(Circle(Point(1,2), 10), "circle", "'<(1,2),10>'");
     }
 }

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -317,7 +317,7 @@ public void _integration_test( string connParam ) @system
         C!Point(Point(1,2), "point", "'(1,2)'");
         C!Line(Line(1,2,3), "line", "'{1,2,3}'");
         C!LineSegment(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
-        //~ C!PGbox(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
+        C!Box(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
         //~ C!PGpath(Path(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
         //~ C!PGpath(Path(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
         //~ C!PGpolygon(Polygon([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -319,8 +319,8 @@ public void _integration_test( string connParam ) @system
         C!LineSegment(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
         C!Box(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
         C!TestPath(TestPath(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
-        //~ C!PGpath(Path(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
-        //~ C!PGpolygon(Polygon([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");
+        C!TestPath(TestPath(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
+        C!Polygon(([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");
         //~ C!PGcircle(Circle(Point(1,2), 10), "circle", "'<(1,2),10>'");
     }
 }

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -318,7 +318,7 @@ public void _integration_test( string connParam ) @system
         C!Line(Line(1,2,3), "line", "'{1,2,3}'");
         C!LineSegment(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
         C!Box(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
-        //~ C!PGpath(Path(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
+        C!TestPath(TestPath(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
         //~ C!PGpath(Path(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
         //~ C!PGpolygon(Polygon([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");
         //~ C!PGcircle(Circle(Point(1,2), 10), "circle", "'<(1,2),10>'");

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -320,7 +320,7 @@ public void _integration_test( string connParam ) @system
             `'{"float_value": 123.456, "text_str": "text string", "abc": {"key": "value"}}'`);
 
         // Geometric
-        import dpq2.conv.geometric: GeometricInstancesForIntegrationTest;
+        import dpq2.conv.geometric: GeometricInstancesForIntegrationTest, toValue;
         mixin GeometricInstancesForIntegrationTest;
 
         C!Point(Point(1,2), "point", "'(1,2)'");

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -316,7 +316,7 @@ public void _integration_test( string connParam ) @system
 
         C!Point(Point(1,2), "point", "'(1,2)'");
         C!Line(Line(1,2,3), "line", "'{1,2,3}'");
-        //~ C!PGlseg(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
+        C!LineSegment(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
         //~ C!PGbox(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
         //~ C!PGpath(Path(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
         //~ C!PGpath(Path(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -182,7 +182,7 @@ mixin template Queries()
 
     // Waiting for completion of reading or writing
     // Returns: timeout is not occured
-    version(unittest)
+    version(integration_tests)
     bool waitEndOf(WaitType type, Duration timeout = Duration.zero)
     {
         import std.socket;
@@ -229,7 +229,7 @@ mixin template Queries()
     }
 }
 
-version(unittest)
+version(integration_tests)
 enum WaitType
 {
     READ,

--- a/src/dpq2/value.d
+++ b/src/dpq2/value.d
@@ -132,7 +132,7 @@ enum ConvExceptionType
     NOT_BINARY, /// Format of the column isn't binary
     NOT_TEXT, /// Format of the column isn't text string
     NOT_IMPLEMENTED, /// Support of this type isn't implemented (or format isn't matches to specified D type)
-    SIZE_MISMATCH, /// Result value size is not matched to the received Postgres value
+    SIZE_MISMATCH, /// Value size is not matched to the Postgres value
     CORRUPTED_JSONB, /// Corrupted JSONB value
     DATE_VALUE_OVERFLOW, /// Date value isn't fits to Postgres binary Date value
 }

--- a/src/dpq2/value.d
+++ b/src/dpq2/value.d
@@ -31,7 +31,7 @@ struct Value
     // Thus, it is need to store reference to Answer here to ensure that result is still available.
 
     /// ctor
-    this(ubyte[] data, in OidType oidType, bool isNull, in ValueFormat format = ValueFormat.BINARY) pure
+    this(ubyte[] data, in OidType oidType, bool isNull = false, in ValueFormat format = ValueFormat.BINARY) pure
     {
         this._data = data;
         this._format = format;


### PR DESCRIPTION
@tchaloupka look at this please

Geometric will allow to use any type of vectors and boxes.
Box bbox() was removed due to redundancy with any math library.

Here is no "standard" type for vectors, boxes etc, so, I removed PG* aliases