### PR TITLE
Fix Box points ordering

### DIFF
--- a/src/dpq2/conv/geometric.d
+++ b/src/dpq2/conv/geometric.d
@@ -88,8 +88,8 @@ if(isValidPointType!Vec2Ddouble)
 
 private auto serializeBox(Box, T)(Box box, T target)
 {
-    auto rem = box.min.serializePoint(target);
-    rem = box.max.serializePoint(rem);
+    auto rem = box.max.serializePoint(target);
+    rem = box.min.serializePoint(rem);
 
     return rem;
 }
@@ -278,10 +278,11 @@ if(isValidBoxType!Box)
 
     alias Point = typeof(Box.min);
 
-    auto min = v.data[0..16].pointFromBytes!Point;
-    auto max = v.data[16..32].pointFromBytes!Point;
+    Box res;
+    res.max = v.data[0..16].pointFromBytes!Point;
+    res.min = v.data[16..32].pointFromBytes!Point;
 
-    return Box(min, max);
+    return res;
 }
 
 T binaryValueAs(T)(in Value v)

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -157,7 +157,7 @@ public void _integration_test( string connParam ) @system
         C!Point(Point(1,2), "point", "'(1,2)'");
         C!PGline(Line(1,2,3), "line", "'{1,2,3}'");
         C!LineSegment(LineSegment(Point(1,2), Point(3,4)), "lseg", "'[(1,2),(3,4)]'");
-        C!Box(Box(Point(3,4), Point(1,2)), "box", "'(3,4),(1,2)'");
+        C!Box(Box(Point(1,2),Point(3,4)), "box", "'(3,4),(1,2)'"); // PG handles box ordered as upper right first and lower left next
         C!TestPath(TestPath(true, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'((1,1),(2,2),(3,3))'");
         C!TestPath(TestPath(false, [Point(1,1), Point(2,2), Point(3,3)]), "path", "'[(1,1),(2,2),(3,3)]'");
         C!Polygon(([Point(1,1), Point(2,2), Point(3,3)]), "polygon", "'((1,1),(2,2),(3,3))'");


### PR DESCRIPTION
Get to geometric patches review after some time now (free time is hard to get) and found a changed order of Box points serialization.

Please look here: https://www.postgresql.org/docs/current/static/datatype-geometric.html#id-1.5.7.16.8

This one especially:
> Any two opposite corners can be supplied on input, but the values will be reordered as needed to store the upper right and lower left corners, in that order.

That means that we should send and receive box in that order too and as Box can now be any object with min and max fields and we don't know the exact meaning of constructor parameters I've changed the deserialization to set fields explicitly so it won't change their meaning.

This is ok for structs, but I'm not sure about classes as with this change it won't compile for them.
We can probably leave it to previous behavior but then it should be a documented requirement to Box be initialized in that exact order.