### PR TITLE
Null string values adjustments, nullable enums support, accept Oid.Name as string

### DIFF
--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -12,7 +12,7 @@ import std.bitmanip: nativeToBigEndian;
 import std.datetime.date: Date, DateTime, TimeOfDay;
 import std.datetime.systime: SysTime;
 import std.datetime.timezone: LocalTime, TimeZone, UTC;
-import std.traits: isImplicitlyConvertible, isNumeric, OriginalType, TemplateArgsOf, Unqual;
+import std.traits: isImplicitlyConvertible, isNumeric, OriginalType, Unqual;
 import std.typecons : Nullable;
 import std.uuid: UUID;
 import vibe.data.json: Json;
@@ -22,7 +22,7 @@ Value toValue(T)(T v)
 if (is(T == Nullable!R, R))
 {
     if (v.isNull)
-        return Value(ValueFormat.BINARY, detectOidTypeFromNative!(TemplateArgsOf!T[0]));
+        return Value(ValueFormat.BINARY, detectOidTypeFromNative!T);
     else
         return toValue(v.get);
 }
@@ -33,8 +33,7 @@ if(isNumeric!(T))
 {
     static if (is(T == enum))
     {
-        alias OType = OriginalType!T;
-        return Value((cast(OType)v).nativeToBigEndian.dup, detectOidTypeFromNative!OType, false, ValueFormat.BINARY);
+        return Value((cast(OriginalType!T)v).nativeToBigEndian.dup, detectOidTypeFromNative!T, false, ValueFormat.BINARY);
     }
     else
     {

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -31,14 +31,7 @@ if (is(T == Nullable!R, R))
 Value toValue(T)(T v)
 if(isNumeric!(T))
 {
-    static if (is(T == enum))
-    {
-        return Value((cast(OriginalType!T)v).nativeToBigEndian.dup, detectOidTypeFromNative!T, false, ValueFormat.BINARY);
-    }
-    else
-    {
-        return Value(v.nativeToBigEndian.dup, detectOidTypeFromNative!T, false, ValueFormat.BINARY);
-    }
+    return Value(v.nativeToBigEndian.dup, detectOidTypeFromNative!T, false, ValueFormat.BINARY);
 }
 
 /**

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -127,6 +127,8 @@ public void _integration_test( string connParam ) @system
         C!Foo(Foo.baz, "Int4", "1");
         C!LongFoo(LongFoo.baz, "Int8", "1");
         C!StringFoo(StringFoo.baz, "text", "'baz'");
+        C!(Nullable!Foo)(Nullable!Foo(Foo.baz), "Int4", "1");
+        C!(Nullable!Foo)(Nullable!Foo.init, "Int4", null);
 
         // date and time testing
         C!PGdate(Date(2016, 01, 8), "date", "'2016-01-08'");

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -46,7 +46,7 @@ public void _integration_test( string connParam ) @system
 
                 auto answer2 = conn.execParams(params);
                 auto v2 = answer2[0][0];
-                auto textResult = v2.as!string.strip(' ');
+                auto textResult = v2.isNull ? null : v2.as!string.strip(' ');
                 pgValue = pgValue.strip('\'');
 
                 // Special cases:
@@ -81,7 +81,8 @@ public void _integration_test( string connParam ) @system
         C!PGtext("first line\nsecond line", "text", "'first line\nsecond line'");
         C!PGtext("12345 ", "char(6)", "'12345'");
         C!PGtext("12345", "varchar(6)", "'12345'");
-        C!PGtext(null, "text", null);
+        C!PGtext(null, "text", "''");
+        C!(Nullable!PGtext)(Nullable!string.init, "text", null);
         C!PGbytea([0x44, 0x20, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x00, 0x21],
             "bytea", r"E'\\x44 20 72 75 6c 65 73 00 21'"); // "D rules\x00!" (ASCII)
         C!PGuuid(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640"), "uuid", "'8b9ab33a-96e9-499b-9c36-aad1fe86d640'");

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -46,7 +46,7 @@ public void _integration_test( string connParam ) @system
 
                 auto answer2 = conn.execParams(params);
                 auto v2 = answer2[0][0];
-                auto textResult = v2.isNull ? null : v2.as!string.strip(' ');
+                auto textResult = v2.isNull ? "NULL" : v2.as!string.strip(' ');
                 pgValue = pgValue.strip('\'');
 
                 // Special cases:
@@ -71,7 +71,7 @@ public void _integration_test( string connParam ) @system
 
         C!PGboolean(true, "boolean", "true");
         C!PGboolean(false, "boolean", "false");
-        C!(Nullable!PGboolean)(Nullable!PGboolean.init, "boolean", null);
+        C!(Nullable!PGboolean)(Nullable!PGboolean.init, "boolean", "NULL");
         C!(Nullable!PGboolean)(Nullable!PGboolean(true), "boolean", "true");
         C!PGsmallint(-32_761, "smallint", "-32761");
         C!PGinteger(-2_147_483_646, "integer", "-2147483646");
@@ -82,7 +82,7 @@ public void _integration_test( string connParam ) @system
         C!PGtext("12345 ", "char(6)", "'12345'");
         C!PGtext("12345", "varchar(6)", "'12345'");
         C!PGtext(null, "text", "''");
-        C!(Nullable!PGtext)(Nullable!string.init, "text", null);
+        C!(Nullable!PGtext)(Nullable!string.init, "text", "NULL");
         C!PGbytea([0x44, 0x20, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x00, 0x21],
             "bytea", r"E'\\x44 20 72 75 6c 65 73 00 21'"); // "D rules\x00!" (ASCII)
         C!PGuuid(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640"), "uuid", "'8b9ab33a-96e9-499b-9c36-aad1fe86d640'");
@@ -120,15 +120,22 @@ public void _integration_test( string connParam ) @system
         foreach(i, s; numericTests)
             C!PGnumeric(s, "numeric", s);
 
-        // enums tests
+        // numeric enums test
         enum Foo { bar, baz }
+        enum ShortFoo :short { bar, baz }
         enum LongFoo : long { bar, baz }
-        enum StringFoo : string { bar = "bar", baz = "baz" }
+
         C!Foo(Foo.baz, "Int4", "1");
+        C!ShortFoo(ShortFoo.baz, "Int2", "1");
         C!LongFoo(LongFoo.baz, "Int8", "1");
-        C!StringFoo(StringFoo.baz, "text", "'baz'");
         C!(Nullable!Foo)(Nullable!Foo(Foo.baz), "Int4", "1");
-        C!(Nullable!Foo)(Nullable!Foo.init, "Int4", null);
+        C!(Nullable!LongFoo)(Nullable!LongFoo.init, "Int8", "NULL");
+
+        // emum : string test
+        enum StringFoo : string { bar = "bar", baz = "baz" }
+        C!StringFoo(StringFoo.baz, "text", "'baz'");
+        C!(Nullable!StringFoo)(Nullable!StringFoo(StringFoo.baz), "text", "'baz'");
+        C!(Nullable!StringFoo)(Nullable!StringFoo.init, "text", "NULL");
 
         // date and time testing
         C!PGdate(Date(2016, 01, 8), "date", "'2016-01-08'");

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -156,7 +156,7 @@ OidType detectOidTypeFromNative(T)()
 {
     import std.datetime.date : StdDate = Date, TimeOfDay;
     import std.datetime.systime : SysTime;
-    import std.traits : OriginalType, TemplateArgsOf, Unqual;
+    import std.traits : isIntegral, OriginalType, TemplateArgsOf, Unqual;
     import std.typecons : Nullable;
     static import dpq2.conv.time;
     import vibe.data.json : VibeJson = Json;
@@ -164,7 +164,10 @@ OidType detectOidTypeFromNative(T)()
     static if(is(Unqual!T == Nullable!R,R))
         return detectOidTypeFromNative!(TemplateArgsOf!T[0]); //remove Nullable from Type before test
     else static if (is(Unqual!T == enum))
+    {
+        static assert(isIntegral!T || is(OriginalType!T == string), "Only integral and string enums are supported");
         return detectOidTypeFromNative!(OriginalType!T); //enum is handled as it's base type
+    }
     else
     {
         alias UT = Unqual!T;

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -156,29 +156,37 @@ OidType detectOidTypeFromNative(T)()
 {
     import std.datetime.date : StdDate = Date, TimeOfDay;
     import std.datetime.systime : SysTime;
-    import std.traits : Unqual;
+    import std.traits : OriginalType, TemplateArgsOf, Unqual;
+    import std.typecons : Nullable;
     static import dpq2.conv.time;
     import vibe.data.json : VibeJson = Json;
 
-    alias UT = Unqual!T;
-
-    with(OidType)
+    static if(is(Unqual!T == Nullable!R,R))
+        return detectOidTypeFromNative!(TemplateArgsOf!T[0]); //remove Nullable from Type before test
+    else static if (is(Unqual!T == enum))
+        return detectOidTypeFromNative!(OriginalType!T); //enum is handled as it's base type
+    else
     {
-        static if(is(UT == string)){ return Text; } else
-        static if(is(UT == ubyte[])){ return ByteArray; } else
-        static if(is(UT == bool)){ return Bool; } else
-        static if(is(UT == short)){ return Int2; } else
-        static if(is(UT == int)){ return Int4; } else
-        static if(is(UT == long)){ return Int8; } else
-        static if(is(UT == float)){ return Float4; } else
-        static if(is(UT == double)){ return Float8; } else
-        static if(is(UT == StdDate)){ return Date; } else
-        static if(is(UT == TimeOfDay)){ return Time; } else
-        static if(is(UT == SysTime)){ return TimeStampWithZone; } else
-        static if(is(UT == dpq2.conv.time.TimeStamp)){ return TimeStamp; } else
-        static if(is(UT == VibeJson)){ return Json; } else
+        alias UT = Unqual!T;
 
-        static assert(false, "Unsupported D type: "~T.stringof);
+        with(OidType)
+        {
+            static if(is(UT == string)){ return Text; } else
+            static if(is(UT == ubyte[])){ return ByteArray; } else
+            static if(is(UT == bool)){ return Bool; } else
+            static if(is(UT == short)){ return Int2; } else
+            static if(is(UT == int)){ return Int4; } else
+            static if(is(UT == long)){ return Int8; } else
+            static if(is(UT == float)){ return Float4; } else
+            static if(is(UT == double)){ return Float8; } else
+            static if(is(UT == StdDate)){ return Date; } else
+            static if(is(UT == TimeOfDay)){ return Time; } else
+            static if(is(UT == SysTime)){ return TimeStampWithZone; } else
+            static if(is(UT == dpq2.conv.time.TimeStamp)){ return TimeStamp; } else
+            static if(is(UT == VibeJson)){ return Json; } else
+
+            static assert(false, "Unsupported D type: "~T.stringof);
+        }
     }
 }
 


### PR DESCRIPTION
When string value is null it should be the same in the DB.
Same goes with Nullable!string and both types should be also read as null from the DB
