### PR TITLE
Add support for UUID array values

### DIFF
--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -176,5 +176,6 @@ public void _integration_test( string connParam ) @system
         //C!(Nullable!string[])([Nullable!string("foo"),Nullable!string.init], "text[]", "'{foo,NULL}'"); //doesn't work due to call of Null.get on value comparisons
         C!(string[])(["foo","bar", "baz"], "text[]", "'{foo,bar,baz}'");
         C!(PGjson[])([Json(["foo": Json(42)])], "json[]", `'{"{\"foo\":42}"}'`);
+        C!(PGuuid[])([UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640")], "uuid[]", "'{8b9ab33a-96e9-499b-9c36-aad1fe86d640}'");
     }
 }

--- a/src/dpq2/conv/to_bson.d
+++ b/src/dpq2/conv/to_bson.d
@@ -143,7 +143,9 @@ Bson rawValueToBson(in Value v)
             break;
 
         case UUID:
-            res = Bson(v.tunnelForBinaryValueAsCalls!PGuuid);
+            // See: https://github.com/vibe-d/vibe.d/issues/2161
+            // res = Bson(v.tunnelForBinaryValueAsCalls!PGuuid);
+            res = serializeToBson(v.tunnelForBinaryValueAsCalls!PGuuid);
             break;
 
         case TimeStampWithZone:
@@ -244,7 +246,10 @@ public void _integration_test( string connParam )
                 )),
                 "bytea", r"E'\\x44 20 72 75 6c 65 73 00 21'"); // "D rules\x00!" (ASCII)
 
-        C(Bson(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640")),
+        //See: https://github.com/vibe-d/vibe.d/issues/2161
+        // C(Bson(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640")),
+        //         "uuid", "'8b9ab33a-96e9-499b-9c36-aad1fe86d640'");
+        C(serializeToBson(UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640")),
                 "uuid", "'8b9ab33a-96e9-499b-9c36-aad1fe86d640'");
 
         C(Bson([

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -113,7 +113,8 @@ shared static this()
             A(Time, TimeArray),
             A(TimeStampWithZone, TimeStampWithZoneArray),
             A(TimeStamp, TimeStampArray),
-            A(Json, JsonArray)
+            A(Json, JsonArray),
+            A(UUID, UUIDArray)
         ];
 
         appropriateArrOid = a;


### PR DESCRIPTION
Unfortunatelly I've found some strange behavior with vibe-d bson serialization while testing this.
UUID[] can't be deserialized from Bson as is read from the PG.
So I changed the read value to be deserializable and created an issue here: https://github.com/vibe-d/vibe.d/issues/2161.

Btw there seems to be some problem in dub repository as last releases aren't reflected there.