### PR TITLE
add support for nullable arrays

### DIFF
--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -32,13 +32,12 @@ if (is(T == Nullable!R, R) && !(isArrayType!(typeof(v.get))))
 Value toValue(T)(T v)
 if (is(T == Nullable!R, R) && (isArrayType!(typeof(v.get))))
 {
-    import dpq2.conv.arrays : arrToValue = toValue; // deprecation import workaround
     import std.range : ElementType;
 
     if (v.isNull)
         return Value(ValueFormat.BINARY, detectOidTypeFromNative!(ElementType!(typeof(v.get))).oidConvTo!"array");
     else
-        return arrToValue(v.get);
+        return toValue(v.get);
 }
 
 ///

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -60,7 +60,8 @@ public void _integration_test( string connParam ) @system
             immutable Value v = answer[0][0];
             static if (isArrayType!T || (is(T==Nullable!R, R) && isArrayType!R))
                 auto result = v.as!Bson.deserializeBson!T; //HACK: There is no direct way to read back the array values using as!.. yet
-            else auto result = v.as!T;
+            else
+                auto result = v.as!T;
 
             static if(isArrayType!T)
                 const bool assertResult = compareArrays(result, nativeValue);

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -58,7 +58,8 @@ public void _integration_test( string connParam ) @system
             params.args = null;
             auto answer = conn.execParams(params);
             immutable Value v = answer[0][0];
-            static if (isArrayType!T) auto result = v.as!Bson.deserializeBson!T; //HACK: There is no direct way to read back the array values using as!.. yet
+            static if (isArrayType!T || (is(T==Nullable!R, R) && isArrayType!R))
+                auto result = v.as!Bson.deserializeBson!T; //HACK: There is no direct way to read back the array values using as!.. yet
             else auto result = v.as!T;
 
             static if(isArrayType!T)
@@ -209,5 +210,6 @@ public void _integration_test( string connParam ) @system
         C!(string[])(["foo","bar", "baz"], "text[]", "'{foo,bar,baz}'");
         C!(PGjson[])([Json(["foo": Json(42)])], "json[]", `'{"{\"foo\":42}"}'`);
         C!(PGuuid[])([UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640")], "uuid[]", "'{8b9ab33a-96e9-499b-9c36-aad1fe86d640}'");
+        C!(Nullable!(int[]))(Nullable!(int[]).init, "int[]", "NULL");
     }
 }

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -211,5 +211,6 @@ public void _integration_test( string connParam ) @system
         C!(PGjson[])([Json(["foo": Json(42)])], "json[]", `'{"{\"foo\":42}"}'`);
         C!(PGuuid[])([UUID("8b9ab33a-96e9-499b-9c36-aad1fe86d640")], "uuid[]", "'{8b9ab33a-96e9-499b-9c36-aad1fe86d640}'");
         C!(Nullable!(int[]))(Nullable!(int[]).init, "int[]", "NULL");
+        C!(Nullable!(int[]))(Nullable!(int[])([1,2,3]), "int[]", "'{1,2,3}'");
     }
 }

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -193,7 +193,7 @@ private OidType detectOidTypeNotCareAboutNullable(T)()
         static if(is(UT == VibeJson)){ return Json; } else
         static if(is(UT == StdUUID)){ return UUID; } else
 
-        static assert(false, "Unsupported D type: "~T.stringof);
+        static assert(false, "Unsupported D type: "~UT.stringof);
     }
 }
 

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -193,7 +193,7 @@ private OidType detectOidTypeNotCareAboutNullable(T)()
         static if(is(UT == VibeJson)){ return Json; } else
         static if(is(UT == StdUUID)){ return UUID; } else
 
-        static assert(false, "Unsupported D type: "~UT.stringof);
+        static assert(false, "Unsupported D type: "~T.stringof);
     }
 }
 


### PR DESCRIPTION
In current `toValue` handler for nullable types there wasn't support for array values because of `detectOidTypeFromNative` does't support it.

I've chosen less intrusive way and just added new toValue templated function for it instead of modifying `detectOidTypeFromNative`.

Please note the `import dpq2.conv.arrays : arrToValue = toValue;` which I had to use to workaround the strange deprecation messages.
I don't understand much why it doesn't work, but there seems to be some problems importing templated functions with same name from different modules in the same scope.

When tried without that, toValue for arrays wasn't found at all (even though it's publicly imported):
```D
src/dpq2/conv/from_d_types.d(34,23): Error: template dpq2.conv.from_d_types.toValue cannot deduce function from argument types !()(int[]), candidates are:
```
When tried with full name `dpq2.conv.arrays.toValue`, I got:
```D
src/dpq2/conv/from_d_types.d(39,20): Deprecation: package dpq2.conv is not accessible here
src/dpq2/conv/from_d_types.d(39,25): Deprecation: module dpq2.conv.arrays is not accessible here, perhaps add static import dpq2.conv.arrays;
```

Which I don't get at all..

So added workaround was the simplest way around it that worked.