### PR TITLE
Fix for "Ddoc: parameter count mismatch" warning

### DIFF
--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -21,6 +21,7 @@ package OidType oid2oidType(Oid oid) pure
  *
  * Params:
  *  s = "array" or "element"
+ *  type = source object type
  */
 OidType oidConvTo(string s)(OidType type)
 {


### PR DESCRIPTION
Rationale: dub builds default with warning as error settings, so using Ddoc builder causes compilation to fail, when Ddoc warns here on this missing parameter description.