### PR TITLE
Enable bulk copy feature into a database table

### DIFF
--- a/src/dpq2/result.d
+++ b/src/dpq2/result.d
@@ -128,8 +128,12 @@ immutable class Answer : Result
             case PGRES_COMMAND_OK:
             case PGRES_TUPLES_OK:
             case PGRES_SINGLE_TUPLE:
+            case PGRES_COPY_IN:
                 break;
 
+            case PGRES_COPY_OUT:
+                throw new AnswerException(ExceptionType.NOT_IMPLEMENTED, "COPY TO not yet supported",
+                    __FILE__, __LINE__);
             default:
                 throw new ResponseException(this, __FILE__, __LINE__);
         }
@@ -695,6 +699,7 @@ enum ExceptionType
     FATAL_ERROR, ///
     COLUMN_NOT_FOUND, /// Column is not found
     OUT_OF_RANGE, ///
+    NOT_IMPLEMENTED, /// A called feature is not implemented
 }
 
 /// Covers errors of access to Answer data


### PR DESCRIPTION
Postgresql's fastest way to upload data into a table is using the COPY command. This implements COPY FROM STDIN, and allows data to be passed from string variables.

Since COPY TO was not properly implemented yet, an exception was added for that type of queries.