### PR TITLE
Add support for const and mutable strings, static array strings.

### DIFF
--- a/src/dpq2/conv/arrays.d
+++ b/src/dpq2/conv/arrays.d
@@ -6,12 +6,25 @@ module dpq2.conv.arrays;
 import dpq2.oids : OidType;
 import dpq2.value;
 
-import std.traits : isArray, isAssociativeArray;
+import std.traits : isArray, isAssociativeArray, isSomeString;
 import std.range : ElementType;
 import std.typecons : Nullable;
 import std.exception: assertThrown;
 
 @safe:
+
+template isStaticArrayString(T)
+{
+    import std.traits : isStaticArray;
+    static if(isStaticArray!T)
+        enum isStaticArrayString = isSomeString!(typeof(T.init[]));
+    else
+        enum isStaticArrayString = false;
+}
+
+static assert(isStaticArrayString!(char[2]));
+static assert(!isStaticArrayString!string);
+static assert(!isStaticArrayString!(ubyte[2]));
 
 // From array to Value:
 
@@ -20,13 +33,15 @@ template isArrayType(T)
     import dpq2.conv.geometric : isValidPolygon;
     import std.traits : Unqual;
 
-    enum isArrayType = isArray!T && !isAssociativeArray!T && !isValidPolygon!T && !is(Unqual!(ElementType!T) == ubyte) && !is(T : string);
+    enum isArrayType = isArray!T && !isAssociativeArray!T && !isValidPolygon!T && !is(Unqual!(ElementType!T) == ubyte) && !isSomeString!T
+        && !isStaticArrayString!T;
 }
 
 static assert(isArrayType!(int[]));
 static assert(!isArrayType!(int[string]));
 static assert(!isArrayType!(ubyte[]));
 static assert(!isArrayType!(string));
+static assert(!isArrayType!(char[2]));
 
 /// Write array element into buffer
 private void writeArrayElement(R, T)(ref R output, T item, ref int counter)

--- a/src/dpq2/conv/to_bson.d
+++ b/src/dpq2/conv/to_bson.d
@@ -86,7 +86,7 @@ Bson rawValueToBson(in Value v)
 {
     if(v.format == ValueFormat.TEXT)
     {
-        const text = v.valueAsString;
+        immutable text = v.valueAsString;
 
         if(v.oidType == OidType.Json)
         {

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -53,7 +53,7 @@ private alias ET = ConvExceptionType;
     Throws: AssertError if the db value is NULL and Nullable is not used to retrieve the value
 */
 T as(T)(in Value v) pure @trusted
-if(is(T : string))
+if(is(T : const(char)[]))
 {
     if(v.format == VF.BINARY)
     {
@@ -108,7 +108,7 @@ if(is(T : string))
     Throws: AssertError if the db value is NULL and Nullable is not used to retrieve the value
 */
 T as(T)(in Value v)
-if(!is(T : string) && !is(T == Bson))
+if(!is(T : const(char)[]) && !is(T == Bson))
 {
     if(!(v.format == VF.BINARY))
         throw new AE(ET.NOT_BINARY,
@@ -142,9 +142,9 @@ auto tunnelForBinaryValueAsCalls(T)(in Value v)
     return binaryValueAs!T(v);
 }
 
-string valueAsString(in Value v) pure
+char[] valueAsString(in Value v) pure
 {
-    return (cast(const(char[])) v.data).to!string;
+    return (cast(const(char[])) v.data).to!(char[]);
 }
 
 /// Returns value as bytes from binary formatted field

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -170,7 +170,7 @@ private OidType detectOidTypeNotCareAboutNullable(T)()
     import std.bitmanip : BitArray;
     import std.datetime.date : StdDate = Date, TimeOfDay, DateTime;
     import std.datetime.systime : SysTime;
-    import std.traits : Unqual;
+    import std.traits : Unqual, isSomeString;
     import std.uuid : StdUUID = UUID;
     static import dpq2.conv.time;
     import vibe.data.json : VibeJson = Json;
@@ -179,7 +179,7 @@ private OidType detectOidTypeNotCareAboutNullable(T)()
 
     with(OidType)
     {
-        static if(is(UT == string)){ return Text; } else
+        static if(isSomeString!UT){ return Text; } else
         static if(is(UT == ubyte[])){ return ByteArray; } else
         static if(is(UT == bool)){ return Bool; } else
         static if(is(UT == short)){ return Int2; } else


### PR DESCRIPTION
Should close #131 I added an appropriate unit test for it.

To make this work, I treated anything that passes `isSomeString` as a string and not an array. In addition, anything that is the static version of that is also treated as a string. Where needed I'm converting to an actual `string`. This is the safest mechanism right now, but I'm not in love with it.

Open to other ideas for fixing. The code in #131 I feel is incorrect in that it assumes it will be an array type, but there is no array of character type. The `char` type in Postgres is actually a string type.