### PR TITLE
Resolve of Nullable.get warnings

### DIFF
--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -4,7 +4,7 @@ module dpq2.conv.from_d_types;
 @safe:
 
 public import dpq2.conv.arrays : isArrayType, toValue, isStaticArrayString;
-public import dpq2.conv.geometric : toValue;
+public import dpq2.conv.geometric : isGeometricType, toValue;
 import dpq2.conv.time : POSTGRES_EPOCH_DATE, TimeStamp, TimeStampUTC;
 import dpq2.oids : detectOidTypeFromNative, oidConvTo, OidType;
 import dpq2.value : Value, ValueFormat;
@@ -21,7 +21,7 @@ import money: currency;
 
 /// Converts Nullable!T to Value
 Value toValue(T)(T v)
-if (is(T == Nullable!R, R) && !(isArrayType!(typeof(v.get))))
+if (is(T == Nullable!R, R) && !(isArrayType!(typeof(v.get))) && !isGeometricType!(typeof(v.get)))
 {
     if (v.isNull)
         return Value(ValueFormat.BINARY, detectOidTypeFromNative!T);
@@ -40,6 +40,18 @@ if (is(T == Nullable!R, R) && (isArrayType!(typeof(v.get))))
         return Value(ValueFormat.BINARY, detectOidTypeFromNative!(ElementType!(typeof(v.get))).oidConvTo!"array");
     else
         return arrToValue(v.get);
+}
+
+/// ditto
+Value toValue(T)(T v)
+if (is(T == Nullable!R, R) && isGeometricType!(typeof(v.get)))
+{
+    import dpq2.conv.geometric : geoToValue = toValue; // deprecation import workaround
+
+    if (v.isNull)
+        return Value(ValueFormat.BINARY, detectOidTypeFromNative!T);
+    else
+        return geoToValue(v.get);
 }
 
 ///

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -172,6 +172,7 @@ private OidType detectOidTypeNotCareAboutNullable(T)()
     import std.datetime.systime : SysTime;
     import std.traits : Unqual, isSomeString;
     import std.uuid : StdUUID = UUID;
+    static import dpq2.conv.geometric;
     static import dpq2.conv.time;
     import vibe.data.json : VibeJson = Json;
 
@@ -196,6 +197,13 @@ private OidType detectOidTypeNotCareAboutNullable(T)()
         static if(is(UT == VibeJson)){ return Json; } else
         static if(is(UT == StdUUID)){ return UUID; } else
         static if(is(UT == BitArray)){ return VariableBitString; } else
+        static if(dpq2.conv.geometric.isValidPointType!UT){ return Point; } else
+        static if(dpq2.conv.geometric.isValidLineType!UT){ return Line; } else
+        static if(dpq2.conv.geometric.isValidPathType!UT){ return Path; } else
+        static if(dpq2.conv.geometric.isValidPolygon!UT){ return Polygon; } else
+        static if(dpq2.conv.geometric.isValidCircleType!UT){ return Circle; } else
+        static if(dpq2.conv.geometric.isValidLineSegmentType!UT){ return LineSegment; } else
+        static if(dpq2.conv.geometric.isValidBoxType!UT){ return Box; } else
 
         static assert(false, "Unsupported D type: "~T.stringof);
     }


### PR DESCRIPTION
Fix cryptic deprecated messages from implicit access of `Nullable.get` through deprecated `alias this`.
Also added support for Nullable geometric types.