### PR TITLE
update money package dependency to at least 3.0.2

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"derelict-pq": "~>4.0.0-alpha.2",
 		"vibe-d:data": ">=0.8.3-beta.1",
-		"money": "~>2.3.0"
+		"money": "~>3.0.2"
 	},
 	"targetType": "sourceLibrary",
 	"-ddoxTool": "scod",


### PR DESCRIPTION
this became necessary as the money package uses the body keyword which was deprecated.