### PR TITLE
Add support for serializing and deserializing records

### DIFF
--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -61,6 +61,7 @@ bool isNativeInteger(OidType t) pure
         case Int8:
         case Int2:
         case Int4:
+        case Oid:
             return true;
         default:
             break;


### PR DESCRIPTION
NB. I haven't added overloads to `as` and `toValue` that take structs because somebody might want extra custom (de)serialization logic, but can add them if you think it would make sense.