### PR TITLE
Negative monetary tests fix

### DIFF
--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -46,6 +46,7 @@ public void _integration_test( string connParam ) @system
     // to return times in other than UTC time zone but fixed time zone so make the test reproducible in databases with other TZ
     conn.exec("SET TIMEZONE TO +02");
 
+    // avoid brackets if negative monetary value passed from server as text
     conn.exec("SET lc_monetary = 'C'");
 
     QueryParams params;

--- a/src/dpq2/conv/native_tests.d
+++ b/src/dpq2/conv/native_tests.d
@@ -46,7 +46,7 @@ public void _integration_test( string connParam ) @system
     // to return times in other than UTC time zone but fixed time zone so make the test reproducible in databases with other TZ
     conn.exec("SET TIMEZONE TO +02");
 
-    conn.exec("SET lc_monetary = 'en_US.UTF-8'");
+    conn.exec("SET lc_monetary = 'C'");
 
     QueryParams params;
     params.resultFormat = ValueFormat.BINARY;


### PR DESCRIPTION
Windows uses different en_US monetary settings:

Value `-$123.45` (as displayed in Debian) in Windows looks like `($123.45)`

This PR switches to identical formats both for Windows and Linux
