### PR TITLE
Correct typo in dub.json: sourcePath => sourcePaths

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -69,7 +69,7 @@
 					}
 				}
 			],
-			"sourcePath": "integration_tests",
+			"sourcePaths": [ "integration_tests" ],
 			"versions": ["integration_tests"]
 		},
 		{
@@ -79,7 +79,7 @@
 			{
 				"dpq2": "*"
 			},
-			"sourcePath": "example"
+			"sourcePaths": [ "example" ]
 		}
 	]
 }


### PR DESCRIPTION
dub v1.30.0 now warns us of this kind of typos.

![image](https://user-images.githubusercontent.com/2180215/203773908-09ee1c44-7cf1-4dca-b1ad-8f78a22393dd.png)
