### PR TITLE
added support for all native user data types PostgreSQL 15

### DIFF
--- a/src/dpq2/conv/arrays.d
+++ b/src/dpq2/conv/arrays.d
@@ -31,10 +31,17 @@ static assert(!isStaticArrayString!(ubyte[2]));
 template isArrayType(T)
 {
     import dpq2.conv.geometric : isValidPolygon;
+    import dpq2.conv.ranges : isMultiRange;
     import std.traits : Unqual;
 
-    enum isArrayType = isArray!T && !isAssociativeArray!T && !isValidPolygon!T && !is(Unqual!(ElementType!T) == ubyte) && !isSomeString!T
-        && !isStaticArrayString!T;
+    enum isArrayType = isArray!T && !(
+        isAssociativeArray!T ||
+        isMultiRange!T ||
+        isValidPolygon!T ||
+        is(Unqual!(ElementType!T) == ubyte) ||
+        isSomeString!T ||
+        isStaticArrayString!T
+    );
 }
 
 static assert(isArrayType!(int[]));

--- a/src/dpq2/conv/bit.d
+++ b/src/dpq2/conv/bit.d
@@ -1,0 +1,50 @@
+module dpq2.conv.bit;
+
+import dpq2.conv.to_d_types;
+import dpq2.oids : OidType;
+import dpq2.value;
+
+import std.bitmanip : bigEndianToNative;
+import std.conv : to;
+import std.exception : enforce;
+import std.traits : hasMember;
+
+
+template isBitString(T) {
+	enum isBitString = hasMember!(T, "bits");
+}
+
+struct BitString {
+	uint stringLen;
+	ubyte[] bits;
+
+	immutable(ubyte)[] _data;
+
+	this(immutable(ubyte)[] binaryData) {
+		enforce(binaryData.length >= uint.sizeof, "cannot construct bit string with insufficient data");
+
+		this._data = binaryData;
+
+		this.stringLen = binaryData[0..uint.sizeof].bigEndianToNative!uint;
+
+		binaryData = binaryData[uint.sizeof..$];
+
+		assert(binaryData.length >= this.byteLen, "data shorter than bit string length");
+		assert(this.stringLen, "zero bit string length?");
+
+		this.bits = binaryData[0..this.byteLen].dup;
+	}
+
+	auto byteLen() @property { return (this.stringLen + 7) / 8; }
+
+	auto rawData() @property { return _data.dup; }
+}
+
+package:
+
+/// Convert Value to native network address type
+N binaryValueAs(N)(in Value v) @trusted
+if (isBitString!N)
+{
+	return N(v.data);
+}

--- a/src/dpq2/conv/net.d
+++ b/src/dpq2/conv/net.d
@@ -1,0 +1,76 @@
+module dpq2.conv.net;
+
+import dpq2.conv.to_d_types;
+import dpq2.oids : OidType;
+import dpq2.value;
+
+import std.bitmanip : bigEndianToNative;
+import std.conv : to;
+import std.exception : enforce;
+import std.format : format;
+import std.socket : AddressFamily;
+import std.traits : hasMember;
+
+
+enum PG_TYPE : ushort {
+	INET_ADDR = 0,
+	CIDR_ADDR = 1
+}
+
+template isNetworkAddress(T) {
+	enum isNetworkAddress = hasMember!(T, "isInet");
+	//pragma(msg, "isNetworkAddress!" ~ T.stringof ~ " = " ~ isNetworkAddress.to!string);
+}
+
+struct NetworkAddress {
+	AddressFamily family;
+	ubyte netmask;
+	PG_TYPE type;
+	ubyte addressLen;
+	ubyte[] address;
+
+	immutable(ubyte)[] _data;
+
+	this(immutable(ubyte)[] binaryData) {
+		enforce(binaryData.length >= uint.sizeof, "cannot construct network address with insufficient data");
+
+		this._data = binaryData;
+
+		this.family = binaryData[0].to!AddressFamily;
+		this.netmask = binaryData[1];
+		this.type = binaryData[2].to!PG_TYPE;
+		this.addressLen = binaryData[3];
+
+		binaryData = binaryData[4..$];
+
+		assert(this.addressLen <= binaryData.length, "data shorter than address length");
+		assert(this.addressLen, "zero address length?");
+
+		this.address = binaryData[0..this.addressLen].dup;
+	}
+
+	bool isInet() @property { return type == PG_TYPE.INET_ADDR; }
+	bool isCidr() @property { return type == PG_TYPE.CIDR_ADDR; }
+
+	auto toString() {
+		switch (this.family) {
+			case AddressFamily.INET:
+				return format("%(%d.%)/%d", this.address[0..this.addressLen], this.netmask);
+
+			case AddressFamily.INET6:
+				return format("%(%x:%)/%d", this.address[0..this.addressLen].to!(ushort[]), this.netmask);
+
+			default:
+				return format("NetowrkAddress(%d,%d,%d,%d,%s)", this.family, this.netmask, this.type, this.addressLen, this.address);
+		}
+	}
+}
+
+package:
+
+/// Convert Value to native network address type
+N binaryValueAs(N)(in Value v) @trusted
+if (isNetworkAddress!N)
+{
+	return N(v.data);
+}

--- a/src/dpq2/conv/ranges.d
+++ b/src/dpq2/conv/ranges.d
@@ -1,0 +1,176 @@
+module dpq2.conv.ranges;
+
+
+import dpq2.conv.time : TimeStamp, TimeStampUTC;
+import dpq2.conv.to_d_types;
+import dpq2.oids : OidType;
+import dpq2.value;
+
+import std.bitmanip : bigEndianToNative;
+import std.conv : to;
+import std.datetime.date : Date;
+import std.exception : enforce;
+import std.traits : TemplateOf;
+
+
+enum PG_RANGE : ubyte {
+	/* A range's flags byte contains these bits: */
+	EMPTY			= 0x01,			/* range is empty */
+	LB_INC			= 0x02,			/* lower bound is inclusive */
+	UB_INC			= 0x04,			/* upper bound is inclusive */
+	LB_INF			= 0x08,			/* lower bound is -infinity */
+	UB_INF			= 0x10,			/* upper bound is +infinity */
+	LB_NULL			= 0x20,			/* lower bound is null (NOT USED) */
+	UB_NULL			= 0x40,			/* upper bound is null (NOT USED) */
+	CONTAIN_EMPTY	= 0x80			/* marks a GiST internal-page entry whose
+									 * subtree contains some empty ranges */
+}
+
+template isRangeType(T, OidType O) {
+	static if (is(T == int)) enum isRangeType = O == OidType.Int4;
+	static if (is(T == long)) enum isRangeType = O == OidType.Int8;
+	static if (is(T == string)) enum isRangeType = O == OidType.Numeric;
+	static if (is(T == TimeStamp)) enum isRangeType = O == OidType.TimeStamp;
+	static if (is(T == TimeStampUTC)) enum isRangeType = O == OidType.TimeStampWithZone;
+	static if (is(T == Date)) enum isRangeType = O == OidType.Date;
+}
+
+template isMultiRange(R) {
+	enum isMultiRange = __traits(isSame, TemplateOf!R, MultiRange);
+}
+
+
+struct Range(T, OidType O, size_t CheckSize = T.sizeof)
+if (isRangeType!(T,O))
+{
+	ubyte flags;
+	T[2] data;
+
+	immutable(ubyte)[] _data;
+
+	this(immutable(ubyte)[] binaryData) {
+		enforce(binaryData.length >= uint.sizeof, "cannot construct range with insufficient data");
+
+		this._data = binaryData;
+
+		this.flags = binaryData[0];
+		binaryData = binaryData[1..$];
+
+		if (CheckSize)
+			assert(binaryData.length ==
+				(isLowerInf || isLowerNull ? 0 : 1)*(uint.sizeof + CheckSize) +
+				(isUpperInf || isUpperNull ? 0 : 1)*(uint.sizeof + CheckSize),
+				"size of binary data does not match: " ~ _data.to!string ~ ", check size = " ~ CheckSize.to!string ~
+				", binaryData.length = " ~ binaryData.length.to!string ~ ", condition = " ~
+					isLowerInf.to!string ~ "/" ~ isLowerNull.to!string ~ "/" ~
+					isUpperInf.to!string ~ "/" ~ isUpperNull.to!string
+			);
+
+		if (!isEmpty) {
+			if (!isLowerInf && !isLowerNull) {
+				auto size = binaryData[0..uint.sizeof].bigEndianToNative!uint;
+				if (CheckSize) assert(size == CheckSize, "unexpected lower bound size");
+				binaryData = binaryData[uint.sizeof..$];
+				this.data[0] = Value(binaryData[0..size].idup, O).as!T;
+				binaryData = binaryData[size..$];
+			}
+
+			if (!isUpperInf && !isUpperNull) {
+				auto size = binaryData[0..uint.sizeof].bigEndianToNative!uint;
+				if (CheckSize) assert(size == CheckSize, "unexpected upper bound size");
+				binaryData = binaryData[uint.sizeof..$];
+				this.data[1] = Value(binaryData[0..size], O).as!T;
+			}
+		}
+	}
+
+	bool isEmpty() @property { return (flags & PG_RANGE.EMPTY) == PG_RANGE.EMPTY; }
+	bool isLowerInc() @property { return (flags & PG_RANGE.LB_INC) == PG_RANGE.LB_INC; }
+	bool isUpperInc() @property { return (flags & PG_RANGE.UB_INC) == PG_RANGE.UB_INC; }
+	bool isLowerInf() @property { return (flags & PG_RANGE.LB_INF) == PG_RANGE.LB_INF; }
+	bool isUpperInf() @property { return (flags & PG_RANGE.UB_INF) == PG_RANGE.UB_INF; }
+	bool isLowerNull() @property { return (flags & PG_RANGE.LB_NULL) == PG_RANGE.LB_NULL; }
+	bool isUpperNull() @property { return (flags & PG_RANGE.UB_NULL) == PG_RANGE.UB_NULL; }
+
+	T lower() { return data[0]; }
+	T upper() { return data[1]; }
+
+	auto rawData() @property { return _data.dup; }
+}
+
+struct MultiRange(R)
+if (__traits(isSame, TemplateOf!R, Range))
+{
+	R[] data;
+
+	immutable(ubyte)[] _data;
+
+	this(immutable(ubyte)[] binaryData) {
+		enforce(binaryData.length >= uint.sizeof, "cannot construct multirange with insufficient data");
+
+		this._data = binaryData;
+		binaryData = binaryData[uint.sizeof..$];
+
+		for (uint i = 0; i < this.length; i++) {
+			auto size = binaryData[0..uint.sizeof].bigEndianToNative!uint;
+			binaryData = binaryData[uint.sizeof..$];
+			data ~= R(binaryData[0..size]);
+			binaryData = binaryData[size..$];
+		}
+	}
+
+	size_t length() @property { return _data.length ? _data[0..uint.sizeof].bigEndianToNative!uint : 0; }
+
+	R opIndex(size_t idx) {
+		enforce(idx < this.length, "multirange index out of bounds: " ~ this.length.to!string ~ "/" ~ idx.to!string);
+		return data[idx];
+	}
+
+	int opApply(scope int delegate(size_t, ref R) dg)
+	{
+		foreach (i, val; data) {
+			if (auto result = dg(i, val))
+				return result;
+		}
+		return 0;
+	}
+
+	int opApplyReverse(scope int delegate(size_t, ref R) dg)
+	{
+		foreach_reverse (i, val; data) {
+			if (auto result = dg(i, val))
+				return result;
+		}
+		return 0;
+	}
+}
+
+alias Range!(int, OidType.Int4) Int4Range;
+alias Range!(long, OidType.Int8) Int8Range;
+alias Range!(string, OidType.Numeric, 0) NumRange;
+alias Range!(TimeStamp, OidType.TimeStamp, 8) TsRange;
+alias Range!(TimeStampUTC, OidType.TimeStampWithZone, 8) TsTzRange;
+alias Range!(Date, OidType.Date) DateRange;
+
+alias MultiRange!Int4Range Int4MultiRange;
+alias MultiRange!Int8Range Int8MultiRange;
+alias MultiRange!NumRange NumMultiRange;
+alias MultiRange!TsRange TsMultiRange;
+alias MultiRange!TsTzRange TsTzMultiRange;
+alias MultiRange!DateRange DateMultiRange;
+
+package:
+
+/// Convert Value to native range type
+R binaryValueAs(R)(in Value v) @trusted
+if (__traits(isSame, TemplateOf!R, Range))
+{
+	return R(v.data);
+}
+
+/// Convert Value to native multirange type
+M binaryValueAs(M)(in Value v) @trusted
+if (__traits(isSame, TemplateOf!M, MultiRange))
+{
+	return M(v.data);
+}

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -12,6 +12,10 @@ import dpq2.conv.from_d_types;
 import dpq2.conv.numeric: rawValueToNumeric;
 import dpq2.conv.time: binaryValueAs, TimeStamp, TimeStampUTC, TimeOfDayWithTZ, Interval;
 import dpq2.conv.geometric: binaryValueAs, Line;
+import dpq2.conv.net : binaryValueAs;
+import dpq2.conv.bit : binaryValueAs;
+import dpq2.conv.ranges : binaryValueAs;
+import dpq2.conv.tsearch : binaryValueAs;
 import dpq2.conv.arrays : binaryValueAs;
 
 import vibe.data.json: Json, parseJsonString;
@@ -77,9 +81,10 @@ if(is(T : const(char)[]) && !is(T == Nullable!R, R))
             v.oidType == OidType.Numeric ||
             v.oidType == OidType.Json ||
             v.oidType == OidType.Jsonb ||
+            v.oidType == OidType.Xml ||
             v.oidType == OidType.Name
         ))
-            throwTypeComplaint(v.oidType, "Text, FixedString, VariableString, Name, Numeric, Json or Jsonb", __FILE__, __LINE__);
+            throwTypeComplaint(v.oidType, "Text, FixedString, VariableString, Name, Numeric, Xml, Json or Jsonb", __FILE__, __LINE__);
     }
 
     if(v.format == VF.BINARY && v.oidType == OidType.Numeric)
@@ -180,7 +185,7 @@ char[] valueAsString(in Value v) pure
 T binaryValueAs(T)(in Value v)
 if(is(T : const ubyte[]))
 {
-    if(!(v.oidType == OidType.ByteArray))
+    if(v.oidType != OidType.ByteArray && v.oidType != OidType.MacAddress && v.oidType != OidType.MacAddress8)
         throwTypeComplaint(v.oidType, "immutable ubyte[]", __FILE__, __LINE__);
 
     return v.data;

--- a/src/dpq2/conv/tsearch.d
+++ b/src/dpq2/conv/tsearch.d
@@ -1,0 +1,212 @@
+module dpq2.conv.tsearch;
+
+import dpq2.conv.to_d_types;
+import dpq2.oids : OidType;
+import dpq2.value;
+
+import std.bitmanip : bigEndianToNative;
+import std.conv : to;
+import std.exception : enforce;
+import std.stdio : writefln;
+import std.string : fromStringz;
+import std.traits : hasMember;
+
+
+template isTsQuery(T) {
+	enum isTsQuery = hasMember!(T, "tokens");
+}
+
+template isTsVector(T) {
+	enum isTsVector = hasMember!(T, "lexemes");
+}
+
+enum TsTokenType : ubyte {
+	TS_TYPE_VAL = 1,
+	TS_TYPE_OPER = 2
+}
+
+enum TsOperator : ubyte {
+	TS_OPER_NOT = 1,
+	TS_OPER_AND = 2,
+	TS_OPER_OR = 3,
+	TS_OPER_PHRASE = 4
+}
+
+struct TsToken {
+	TsTokenType type;
+	union {
+		struct Oper {
+			TsOperator operator;
+			ushort distance;
+		}
+		Oper oper;
+		struct Value {
+			ubyte weight;
+			bool prefix;
+			string value;
+		}
+		Value val;
+	}
+}
+
+struct TsLexeme {
+	string value;
+	ushort[] wordEntryPos;
+
+	static ushort weightAsNumber(ushort wordEntry) { return wordEntry >> 14; }
+	static char weightAsChar(ushort wordEntry) { return 'D' - (wordEntry >> 14); }
+	static ushort pos(ushort wordEntry) { return wordEntry & 0x3FFF; }
+}
+
+struct TsQuery {
+	TsToken[] tokens;
+
+	immutable(ubyte)[] _data;
+
+	this(immutable(ubyte)[] binaryData) {
+		enforce(binaryData.length >= uint.sizeof, "cannot construct text search query with insufficient data");
+
+		this._data = binaryData;
+
+		auto count = binaryData[0..uint.sizeof].bigEndianToNative!uint;
+
+		binaryData = binaryData[uint.sizeof..$];
+
+		assert(count, "zero token count?");
+
+		for (uint i = 0; i < count; i++) {
+			TsToken token;
+
+			token.type = binaryData[0..ubyte.sizeof].bigEndianToNative!ubyte.to!TsTokenType;
+			binaryData = binaryData[ubyte.sizeof..$];
+
+			final switch (token.type) {
+				case TsTokenType.TS_TYPE_VAL:
+					token.val.weight = binaryData[0..ubyte.sizeof].bigEndianToNative!ubyte;
+					binaryData = binaryData[ubyte.sizeof..$];
+
+					token.val.prefix = binaryData[0..ubyte.sizeof].bigEndianToNative!ubyte.to!bool;
+					binaryData = binaryData[ubyte.sizeof..$];
+
+					token.val.value = fromStringz(cast(char*)binaryData.ptr).to!string;
+					binaryData = binaryData[token.val.value.length+1..$];
+					break;
+
+				case TsTokenType.TS_TYPE_OPER:
+					token.oper.operator = binaryData[0..ubyte.sizeof].bigEndianToNative!ubyte.to!TsOperator;
+					binaryData = binaryData[ubyte.sizeof..$];
+
+					if (token.oper.operator == TsOperator.TS_OPER_PHRASE) {
+						token.oper.distance = binaryData[0..ushort.sizeof].bigEndianToNative!ushort;
+						binaryData = binaryData[ushort.sizeof..$];
+					}
+					break;
+			}
+			this.tokens ~= token;
+		}
+	}
+
+	size_t length() @property { return tokens.length; }
+
+	auto opIndex(size_t idx) {
+		enforce(idx < this.tokens.length, "tokens index out of bounds: " ~ this.tokens.length.to!string ~ "/" ~ idx.to!string);
+		return tokens[idx];
+	}
+
+	int opApply(scope int delegate(size_t, ref TsToken) dg)
+	{
+		foreach (i, val; tokens) {
+			if (auto result = dg(i, val))
+				return result;
+		}
+		return 0;
+	}
+
+	int opApplyReverse(scope int delegate(size_t, ref TsToken) dg)
+	{
+		foreach_reverse (i, val; tokens) {
+			if (auto result = dg(i, val))
+				return result;
+		}
+		return 0;
+	}
+
+	auto rawData() @property { return _data.dup; }
+}
+
+struct TsVector {
+	TsLexeme[] lexemes;
+
+	immutable(ubyte)[] _data;
+
+	this(immutable(ubyte)[] binaryData) {
+		enforce(binaryData.length >= uint.sizeof, "cannot construct text search vector with insufficient data");
+
+		this._data = binaryData;
+
+		auto count = binaryData[0..uint.sizeof].bigEndianToNative!uint;
+
+		binaryData = binaryData[uint.sizeof..$];
+
+		assert(count, "zero lexeme count?");
+
+		for (uint i = 0; i < count; i++) {
+			TsLexeme lexeme;
+
+			lexeme.value = fromStringz(cast(char*)binaryData.ptr).to!string;
+			binaryData = binaryData[lexeme.value.length+1..$];
+
+			auto posCount = binaryData[0..ushort.sizeof].bigEndianToNative!ushort;
+			binaryData = binaryData[ushort.sizeof..$];
+
+			for (uint j = 0; j < posCount; j++) {
+				lexeme.wordEntryPos ~= binaryData[0..ushort.sizeof].bigEndianToNative!ushort;
+				binaryData = binaryData[ushort.sizeof..$];
+			}
+			this.lexemes ~= lexeme;
+		}
+	}
+
+	size_t length() @property { return lexemes.length; }
+
+	auto opIndex(size_t idx) {
+		enforce(idx < this.lexemes.length, "lexemes index out of bounds: " ~ this.lexemes.length.to!string ~ "/" ~ idx.to!string);
+		return lexemes[idx];
+	}
+
+	int opApply(scope int delegate(size_t, ref TsLexeme) dg)
+	{
+		foreach (i, val; lexemes) {
+			if (auto result = dg(i, val))
+				return result;
+		}
+		return 0;
+	}
+
+	int opApplyReverse(scope int delegate(size_t, ref TsLexeme) dg)
+	{
+		foreach_reverse (i, val; lexemes) {
+			if (auto result = dg(i, val))
+				return result;
+		}
+		return 0;
+	}
+
+	auto rawData() @property { return _data.dup; }
+}
+
+package:
+
+/// Convert Value to native text search query type
+TQ binaryValueAs(TQ)(in Value v) @trusted
+if (isTsQuery!TQ)
+{
+	return TQ(v.data);
+}
+
+/// Convert Value to native text search vector type
+TV binaryValueAs(TV)(in Value v) @trusted
+if (isTsVector!TV)
+{
+	return TV(v.data);
+}

--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -62,6 +62,7 @@ bool isNativeInteger(OidType t) pure
         case Int2:
         case Int4:
         case Oid:
+        case Money:
             return true;
         default:
             break;
@@ -104,21 +105,57 @@ shared static this()
     {
         immutable AppropriateArrOid[] a =
         [
-            A(Text, TextArray),
-            A(Name, NameArray),
             A(Bool, BoolArray),
-            A(Int2, Int2Array),
-            A(Int4, Int4Array),
-            A(Int8, Int8Array),
+            A(Box, BoxArray),
+            A(ByteArray, ByteArrayArray),
+            A(Char, CharArray),
+            A(Circle, CircleArray),
+            A(Date, DateArray),
+            A(DateMultiRange, DateMultiRangeArray),
+            A(DateRange, DateRangeArray),
+            A(FixedBitString, FixedBitStringArray),
+            A(FixedString, FixedStringArray),
             A(Float4, Float4Array),
             A(Float8, Float8Array),
-            A(Date, DateArray),
-            A(Time, TimeArray),
-            A(TimeWithZone, TimeWithZoneArray),
-            A(TimeStampWithZone, TimeStampWithZoneArray),
-            A(TimeStamp, TimeStampArray),
+            A(HostAddress, HostAddressArray),
+            A(Int2, Int2Array),
+            A(Int4, Int4Array),
+            A(Int4MultiRange, Int4MultiRangeArray),
+            A(Int4Range, Int4RangeArray),
+            A(Int8, Int8Array),
+            A(Int8MultiRange, Int8MultiRangeArray),
+            A(Int8Range, Int8RangeArray),
             A(Json, JsonArray),
-            A(UUID, UUIDArray)
+            A(Jsonb, JsonbArray),
+            A(Line, LineArray),
+            A(LineSegment, LineSegmentArray),
+            A(MacAddress8, MacAddress8Array),
+            A(MacAddress, MacAddressArray),
+            A(Money, MoneyArray),
+            A(Name, NameArray),
+            A(NetworkAddress, NetworkAddressArray),
+            A(Numeric, NumericArray),
+            A(NumMultiRange, NumMultiRangeArray),
+            A(NumRange, NumRangeArray),
+            A(Path, PathArray),
+            A(Point, PointArray),
+            A(Polygon, PolygonArray),
+            A(Text, TextArray),
+            A(Time, TimeArray),
+            A(TimeInterval, TimeIntervalArray),
+            A(TimeStamp, TimeStampArray),
+            A(TimeStampMultiRange, TimeStampMultiRangeArray),
+            A(TimeStampRange, TimeStampRangeArray),
+            A(TimeStampWithZone, TimeStampWithZoneArray),
+            A(TimeStampWithZoneMultiRange, TimeStampWithZoneMultiRangeArray),
+            A(TimeStampWithZoneRange, TimeStampWithZoneRangeArray),
+            A(TimeWithZone, TimeWithZoneArray),
+            A(TSQuery, TSQueryArray),
+            A(TSVector, TSVectorArray),
+            A(UUID, UUIDArray),
+            A(VariableBitString, VariableBitStringArray),
+            A(VariableString, VariableStringArray),
+            A(Xml, XmlArray)
         ];
 
         appropriateArrOid = a;
@@ -133,24 +170,56 @@ bool isSupportedArray(OidType t) pure nothrow @nogc
     switch(t)
     {
         case BoolArray:
+        case BoxArray:
         case ByteArrayArray:
         case CharArray:
-        case Int2Array:
-        case Int4Array:
-        case TextArray:
-        case NameArray:
-        case Int8Array:
+        case CircleArray:
+        case DateArray:
+        case DateMultiRangeArray:
+        case DateRangeArray:
+        case FixedBitStringArray:
+        case FixedStringArray:
         case Float4Array:
         case Float8Array:
-        case TimeStampArray:
-        case TimeStampWithZoneArray:
-        case DateArray:
-        case TimeArray:
-        case TimeWithZoneArray:
-        case NumericArray:
-        case UUIDArray:
+        case HostAddressArray:
+        case Int2Array:
+        case Int4Array:
+        case Int4MultiRangeArray:
+        case Int4RangeArray:
+        case Int8Array:
+        case Int8MultiRangeArray:
+        case Int8RangeArray:
         case JsonArray:
         case JsonbArray:
+        case LineArray:
+        case LineSegmentArray:
+        case MacAddress8Array:
+        case MacAddressArray:
+        case MoneyArray:
+        case NameArray:
+        case NetworkAddressArray:
+        case NumericArray:
+        case NumMultiRangeArray:
+        case NumRangeArray:
+        case PathArray:
+        case PointArray:
+        case PolygonArray:
+        case TextArray:
+        case TimeArray:
+        case TimeIntervalArray:
+        case TimeStampArray:
+        case TimeStampMultiRangeArray:
+        case TimeStampRangeArray:
+        case TimeStampWithZoneArray:
+        case TimeStampWithZoneMultiRangeArray:
+        case TimeStampWithZoneRangeArray:
+        case TimeWithZoneArray:
+        case TSQueryArray:
+        case TSVectorArray:
+        case UUIDArray:
+        case VariableBitStringArray:
+        case VariableStringArray:
+        case XmlArray:
             return true;
         default:
             break;
@@ -264,6 +333,7 @@ public enum OidType : Oid
     Circle = 718, ///
     Money = 790, ///
     MacAddress = 829, ///
+    MacAddress8 = 774,
     HostAddress = 869, ///
     NetworkAddress = 650, ///
 
@@ -303,8 +373,19 @@ public enum OidType : Oid
     DateRange = 3912, ///
     Int8Range = 3926, ///
 
+    Int4MultiRange = 4451,
+    NumMultiRange = 4532,
+    TimeStampMultiRange = 4533,
+    TimeStampWithZoneMultiRange = 4534,
+    DateMultiRange = 4535,
+    Int8MultiRange = 4536,
+
     // Arrays
     XmlArray = 143, ///
+    LineArray = 629,
+    CircleArray = 719,
+    MacAddress8Array = 775,
+    MoneyArray = 791,
     JsonbArray = 3807, ///
     JsonArray = 199, ///
     BoolArray = 1000, ///
@@ -336,8 +417,8 @@ public enum OidType : Oid
     PolygonArray = 1027, ///
     AccessControlListArray = 1034, ///
     MacAddressArray = 1040, ///
-    HostAdressArray = 1041, ///
-    NetworkAdressArray = 651, ///
+    HostAddressArray = 1041, ///
+    NetworkAddressArray = 651, ///
     CStringArray = 1263, ///
     TimeStampArray = 1115, ///
     DateArray = 1182, ///
@@ -367,6 +448,13 @@ public enum OidType : Oid
     TimeStampWithZoneRangeArray = 3911, ///
     DateRangeArray = 3913, ///
     Int8RangeArray = 3927, ///
+
+    Int4MultiRangeArray = 6150,
+    NumMultiRangeArray = 6151,
+    TimeStampMultiRangeArray = 6152,
+    TimeStampWithZoneMultiRangeArray = 6153,
+    DateMultiRangeArray = 6155,
+    Int8MultiRangeArray = 6157,
 
     // Pseudo types
     Record = 2249, ///


### PR DESCRIPTION
Hello, I have added support for all native PostgreSQL user data types (ranges, multiranges, network, bitstrings, geometry, xml and text search vector/query), for now except for multi-dimensional arrays and user-defined types. In order to add support for OidType.PointArray I had to explicitely distinguish between Point[] and Polygon by defining a solid struct Point in dpq2.conv.geometry. Please review and incorporate the changes in the code base on your sole discretion.