### PR TITLE
Added FORMAT(binary) copy capability and example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dub.selections.json
 *.lst
 docs
 docs.json
+example/dpq2_example*

--- a/src/dpq2/query.d
+++ b/src/dpq2/query.d
@@ -207,6 +207,30 @@ mixin template Queries()
         return r != 0;
     }
 
+    /// Sends a buffer of binary data to the COPY command
+    ///
+    /// A details example setup and iteration for binary data copy-in 
+    /// can be found in example/example.d
+    ///
+    /// Before using this function execute a command similar to the 
+    /// the following:
+    /// ---
+    /// conn.exec("CREATE TEMP TABLE mytable (mycol1 int, mycol2 real)");
+    /// ---
+    ///
+    /// where the column names an types depend on the destination table.
+    /// Returns:
+    ///   true if the data was queued, false if it was not queued because of
+    ///   full buffers (this will only happen in nonblocking mode)
+    bool putCopyData(const(ubyte)[] data )
+    {
+        const int r = PQputCopyData(conn, cast(const char*)data.ptr, data.length.to!int);
+
+        if(r == -1) throw new ConnectionException(this);
+
+        return r != 0;
+    }
+
     /// Signals that COPY data send is finished. Finalize and flush the COPY command.
     immutable(Answer) putCopyEnd()
     {
@@ -501,19 +525,11 @@ void _integration_test( string connParam ) @trusted
     conn.socket.shutdown(SocketShutdown.BOTH); // breaks connection
 
     {
-        import dpq2.result: ResponseException;
-
         bool exceptionFlag = false;
         string errorMsg;
 
         try conn.exec("SELECT 'abc'::text").getAnswer;
         catch(ConnectionException e)
-        {
-            exceptionFlag = true;
-            errorMsg = e.msg;
-            assert(e.msg.length > 15); // error message check
-        }
-        catch(ResponseException e)
         {
             exceptionFlag = true;
             errorMsg = e.msg;


### PR DESCRIPTION
Hi Denizzzka

The dpq2 library met most of my needs, but a small update was added to assist with fast binary copy-in.   The changes are:

1. The function Connection.putCopyData was overloaded to take const(ubyte[]) values since these are common for raw data. 
2. The example.d file was updated to include an explicit binary copy-in example for variable length BYTEA types in a tight loop
3. example.d was given a dub --single recipe to make it easier to build.

I certainly don't expect you to accept these changes upstream, but wanted to offer them in case they are useful.

Thanks for creating dpq2!