### PR TITLE
RecordArray works, so enable it

### DIFF
--- a/src/dpq2/oids.d
+++ b/src/dpq2/oids.d
@@ -153,6 +153,7 @@ bool isSupportedArray(OidType t) pure nothrow @nogc
         case LineArray:
         case JsonArray:
         case JsonbArray:
+        case RecordArray:
             return true;
         default:
             break;


### PR DESCRIPTION
Example:
```d
import std.array;
import std.algorithm;

import dpq2;

struct Data
{
	int id;
	string text;
}

Data[] getData()
{
	Connection conn = new Connection("postgresql://");
	QueryParams qp = QueryParams(`
		select array_agg(t.*) as records_array
		from (
			values 
				(1, 'example'),
				(2, 'test')
		) as t`
	);
	immutable Row row = conn.execParams(qp)[0];
	immutable Array recordsArray = row["records_array"].asArray();

	return recordsArray.rangify.map!(
		(Value value) {
			Value[] record = value.deserializeRecord();
			return Data(
				record[0].as!int,
				record[1].as!string,
			);
		}
	).array;
}
```