### PR TITLE
Answer: adds cell accessors .oneRow() and .oneCell()

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ void main(string[] args)
     scope(exit) destroy(r);
 
     writeln( "0: ", r[0]["double_field"].as!PGdouble_precision );
-    writeln( "1: ", r[0][1].as!PGtext );
+    writeln( "1: ", r.oneRow[1].as!PGtext ); // .oneRow additionally checks that here is only one row was returned
     writeln( "2.1 isNull: ", r[0][2].isNull );
     writeln( "2.2 isNULL: ", r[0].isNULL(2) );
     writeln( "3.1: ", r[0][3].asArray[0].as!PGtext );

--- a/example/example.d
+++ b/example/example.d
@@ -50,7 +50,7 @@ void main(string[] args)
     scope(exit) destroy(r);
 
     writeln( "0: ", r[0]["double_field"].as!PGdouble_precision );
-    writeln( "1: ", r[0][1].as!PGtext );
+    writeln( "1: ", r.oneRow[1].as!PGtext ); // .oneRow additionally checks that here is only one row was returned
     writeln( "2.1 isNull: ", r[0][2].isNull );
     writeln( "2.2 isNULL: ", r[0].isNULL(2) );
     writeln( "3.1: ", r[0][3].asArray[0].as!PGtext );

--- a/src/dpq2/result.d
+++ b/src/dpq2/result.d
@@ -412,6 +412,22 @@ immutable struct Row
         return answer.columnName( colNum );
     }
 
+    /// Checks Row to make sure that it contains exactly one column
+    /// and returns this one found cell Value
+    ///
+    /// Returns: cell Value
+    immutable(Value) oneCell(string file = __FILE__, size_t line = __LINE__)
+    {
+        if(length != 1)
+            throw new AnswerException(
+                    ExceptionType.UNEXPECTED_LENGTH,
+                    "Row contains "~length.to!string~" columns, but expected 1",
+                    file, line
+                );
+
+        return opIndex(0);
+    }
+
     /// Returns column count
     size_t length() { return answer.columnCount(); }
 
@@ -883,6 +899,7 @@ void _integration_test( string connParam )
         assertThrown!ValueConvException(r[0]["unsupported_toString_output_type"].toString);
 
         assert(r.oneRow[0].as!short == -32761);
+        assertThrown!AnswerException(r.oneRow.oneCell);
 
         // Access to NULL cell
         {
@@ -905,6 +922,13 @@ void _integration_test( string connParam )
             finally
                 assert(isNullFlag);
         }
+    }
+
+    // oneRow/oneCell tests
+    {
+        const o = conn.exec("select 'test_value'");
+
+        assert(o.oneRow.oneCell.as!string == "test_value");
     }
 
     // Notifies test

--- a/src/dpq2/result.d
+++ b/src/dpq2/result.d
@@ -251,6 +251,14 @@ immutable class Answer : Result
         return opIndex(0);
     }
 
+    /// Checks Answer to make sure that it contains exactly one Row and one column
+    /// and returns this one found cell Value
+    ///
+    /// Returns: cell Value
+    immutable(Value) oneCell(string file = __FILE__, size_t line = __LINE__)
+    {
+        return this.oneRow(file, line).oneCell(file, line);
+    }
 
     /**
      Returns the number of parameters of a prepared statement.
@@ -900,6 +908,7 @@ void _integration_test( string connParam )
 
         assert(r.oneRow[0].as!short == -32761);
         assertThrown!AnswerException(r.oneRow.oneCell);
+        assertThrown!AnswerException(r.oneCell);
 
         // Access to NULL cell
         {
@@ -929,6 +938,7 @@ void _integration_test( string connParam )
         const o = conn.exec("select 'test_value'");
 
         assert(o.oneRow.oneCell.as!string == "test_value");
+        assert(o.oneCell.as!string == "test_value");
     }
 
     // Notifies test

--- a/src/dpq2/result.d
+++ b/src/dpq2/result.d
@@ -235,6 +235,23 @@ immutable class Answer : Result
         return immutable Row(this, row);
     }
 
+    /// Checks Answer to make sure that it contains exactly one Row
+    /// and returns this one row
+    ///
+    /// Returns: Row of cells
+    immutable(Row) oneRow(string file = __FILE__, size_t line = __LINE__)
+    {
+        if(length != 1)
+            throw new AnswerException(
+                    ExceptionType.UNEXPECTED_LENGTH,
+                    "Answer contains "~length.to!string~" rows, but expected 1",
+                    file, line
+                );
+
+        return opIndex(0);
+    }
+
+
     /**
      Returns the number of parameters of a prepared statement.
      This function is only useful when inspecting the result of describePrepared.
@@ -761,6 +778,7 @@ enum ExceptionType
     FATAL_ERROR, ///
     COLUMN_NOT_FOUND, /// Column is not found
     OUT_OF_RANGE, ///
+    UNEXPECTED_LENGTH, ///
     COPY_OUT_NOT_IMPLEMENTED = 10000, /// TODO
 }
 
@@ -807,6 +825,8 @@ void _integration_test( string connParam )
         assert( e[1]["field_name"].as!PGtext == "def" );
         assert(e.columnExists("field_name"));
         assert(!e.columnExists("foo"));
+
+        assertThrown!AnswerException(e.oneRow);
     }
 
     // Binary type arguments testing:
@@ -861,6 +881,8 @@ void _integration_test( string connParam )
 
         r[0].toString; // Must not throw
         assertThrown!ValueConvException(r[0]["unsupported_toString_output_type"].toString);
+
+        assert(r.oneRow[0].as!short == -32761);
 
         // Access to NULL cell
         {


### PR DESCRIPTION
Many years of practice have shown that almost any project sooner or later becomes overgrown with these access primitives. It is time to implement them directly into dpq2